### PR TITLE
feat: página de configuración con menú lateral

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Buy Buddies</title>
   </head>
   <body>
-    <shopping-list></shopping-list>
+    <app-root></app-root>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,1 @@
-import './ui/shopping-list.js';
-
-document.addEventListener('DOMContentLoaded', () => {
-  const list = document.createElement('shopping-list');
-  document.body.appendChild(list);
-});
+import './ui/app-root.js';

--- a/src/ui/app-root.test.ts
+++ b/src/ui/app-root.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { fixture, html } from '@open-wc/testing';
+import { vi } from 'vitest';
+
+vi.mock('@material/web/iconbutton/icon-button.js', () => ({}));
+vi.mock('@material/web/labs/navigationdrawer/navigation-drawer.js', () => ({}));
+vi.mock('@material/web/list/list.js', () => ({}));
+vi.mock('@material/web/list/list-item.js', () => ({}));
+vi.mock('@material/web/textfield/outlined-text-field.js', () => ({}));
+
+import './app-root.js';
+
+if (!customElements.get('md-icon-button')) {
+  customElements.define('md-icon-button', class extends HTMLElement {});
+}
+if (!customElements.get('md-navigation-drawer')) {
+  customElements.define(
+    'md-navigation-drawer',
+    class extends HTMLElement {
+      open = false;
+    },
+  );
+}
+if (!customElements.get('md-list')) {
+  customElements.define('md-list', class extends HTMLElement {});
+}
+if (!customElements.get('md-list-item')) {
+  customElements.define('md-list-item', class extends HTMLElement {});
+}
+if (!customElements.get('md-outlined-text-field')) {
+  customElements.define('md-outlined-text-field', class extends HTMLElement {});
+}
+
+declare global {
+  interface Window {
+    fetch: typeof fetch;
+  }
+}
+
+describe('app-root component', () => {
+  beforeEach(() => {
+    window.fetch = async () => new Response('[]', { status: 200 }) as any;
+  });
+
+  it('navigates to config page', async () => {
+    const el = await fixture<HTMLDivElement>(html`<app-root></app-root>`);
+    await el.updateComplete;
+
+    const drawer = el.shadowRoot?.querySelector(
+      'md-navigation-drawer',
+    ) as HTMLElement & { open: boolean };
+    drawer.open = true;
+    const items = drawer.querySelectorAll('md-list-item');
+    (items[1] as HTMLElement).click();
+    await el.updateComplete;
+
+    expect(el.shadowRoot?.textContent).toContain('Configuración');
+  });
+});

--- a/src/ui/app-root.ts
+++ b/src/ui/app-root.ts
@@ -1,0 +1,75 @@
+import { LitElement, html, css } from 'lit';
+import { customElement, state, query } from 'lit/decorators.js';
+import '@material/web/iconbutton/icon-button.js';
+import '@material/web/labs/navigationdrawer/navigation-drawer.js';
+import '@material/web/list/list.js';
+import '@material/web/list/list-item.js';
+import './shopping-list.js';
+import './config-page.js';
+
+@customElement('app-root')
+export class AppRoot extends LitElement {
+  static styles = css`
+    .top-bar {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 16px;
+    }
+
+    .title {
+      font-size: 1.25rem;
+    }
+
+    main {
+      padding: 16px;
+    }
+  `;
+
+  @state()
+  private page: 'shopping' | 'config' = 'shopping';
+
+  @query('md-navigation-drawer')
+  private drawer!: HTMLElement & { open: boolean };
+
+  private openDrawer() {
+    this.drawer.open = true;
+  }
+
+  private navigate(page: 'shopping' | 'config') {
+    this.page = page;
+    this.drawer.open = false;
+  }
+
+  render() {
+    return html`
+      <header class="top-bar">
+        <md-icon-button @click=${this.openDrawer}>
+          <svg slot="icon" viewBox="0 0 24 24">
+            <path d="M3 6h18v2H3V6zm0 5h18v2H3v-2zm0 5h18v2H3v-2z"></path>
+          </svg>
+        </md-icon-button>
+        <div class="title">Buy Buddies</div>
+      </header>
+
+      <md-navigation-drawer type="modal">
+        <md-list>
+          <md-list-item @click=${() => this.navigate('shopping')}>Lista</md-list-item>
+          <md-list-item @click=${() => this.navigate('config')}>Configuración</md-list-item>
+        </md-list>
+      </md-navigation-drawer>
+
+      <main>
+        ${this.page === 'config'
+          ? html`<config-page></config-page>`
+          : html`<shopping-list></shopping-list>`}
+      </main>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'app-root': AppRoot;
+  }
+}

--- a/src/ui/config-page.ts
+++ b/src/ui/config-page.ts
@@ -1,0 +1,27 @@
+import { LitElement, html, css } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('config-page')
+export class ConfigPage extends LitElement {
+  static styles = css`
+    :host {
+      display: block;
+      padding: 16px;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 1.5rem;
+    }
+  `;
+
+  render() {
+    return html`<h1>Configuración</h1>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'config-page': ConfigPage;
+  }
+}


### PR DESCRIPTION
## Summary
- agrega `app-root` con navegación lateral para móvil
- añade página de configuración básica con título
- incorpora prueba de integración para navegar a configuración desde el menú

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688db018d0648321b9598c31fecfc77f