### PR TITLE
Integrate Vaadin Router for navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@material/web": "^2.3.0",
+        "@vaadin/router": "^1.7.5",
         "google-auth-library": "^10.2.0",
         "google-spreadsheet": "^4.1.5",
         "lit": "^3.3.1"
@@ -1392,6 +1393,35 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@vaadin/router": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@vaadin/router/-/router-1.7.5.tgz",
+      "integrity": "sha512-uRN3vd1ihgd596bF/NMZqpgxau0nlvIc0/JDd1EwStFNbZID/xIVse5LXdQhIyUKLmSl4T0GeCQK505xerWX0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vaadin/vaadin-usage-statistics": "^2.1.0",
+        "path-to-regexp": "2.4.0"
+      }
+    },
+    "node_modules/@vaadin/vaadin-development-mode-detector": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-development-mode-detector/-/vaadin-development-mode-detector-2.0.7.tgz",
+      "integrity": "sha512-9FhVhr0ynSR3X2ao+vaIEttcNU5XfzCbxtmYOV8uIRnUCtNgbvMOIcyGBvntsX9I5kvIP2dV3cFAOG9SILJzEA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@vaadin/vaadin-usage-statistics": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.1.3.tgz",
+      "integrity": "sha512-8r4TNknD7OJQADe3VygeofFR7UNAXZ2/jjBFP5dgI8+2uMfnuGYgbuHivasKr9WSQ64sPej6m8rDoM1uSllXjQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vaadin/vaadin-development-mode-detector": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -3875,6 +3905,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+      "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "type": "module",
   "dependencies": {
     "@material/web": "^2.3.0",
+    "@vaadin/router": "^1.7.5",
     "google-auth-library": "^10.2.0",
     "google-spreadsheet": "^4.1.5",
     "lit": "^3.3.1"

--- a/src/ui/app-root.test.ts
+++ b/src/ui/app-root.test.ts
@@ -52,8 +52,9 @@ describe('app-root component', () => {
     drawer.open = true;
     const items = drawer.querySelectorAll('md-list-item');
     (items[1] as HTMLElement).click();
-    await el.updateComplete;
+    await new Promise((r) => setTimeout(r));
 
+    expect(window.location.pathname).toBe('/config');
     expect(el.shadowRoot?.textContent).toContain('Configuración');
   });
 });

--- a/src/ui/app-root.ts
+++ b/src/ui/app-root.ts
@@ -1,5 +1,6 @@
 import { LitElement, html, css } from 'lit';
-import { customElement, state, query } from 'lit/decorators.js';
+import { customElement, query } from 'lit/decorators.js';
+import { Router } from '@vaadin/router';
 import '@material/web/iconbutton/icon-button.js';
 import '@material/web/labs/navigationdrawer/navigation-drawer.js';
 import '@material/web/list/list.js';
@@ -26,18 +27,27 @@ export class AppRoot extends LitElement {
     }
   `;
 
-  @state()
-  private page: 'shopping' | 'config' = 'shopping';
-
   @query('md-navigation-drawer')
   private drawer!: HTMLElement & { open: boolean };
+
+  private router!: Router;
+
+  firstUpdated() {
+    this.router = new Router(
+      this.shadowRoot!.getElementById('outlet') as HTMLElement,
+    );
+    this.router.setRoutes([
+      { path: '/', component: 'shopping-list' },
+      { path: '/config', component: 'config-page' },
+    ]);
+  }
 
   private openDrawer() {
     this.drawer.open = true;
   }
 
-  private navigate(page: 'shopping' | 'config') {
-    this.page = page;
+  private navigate(path: string) {
+    Router.go(path);
     this.drawer.open = false;
   }
 
@@ -54,15 +64,13 @@ export class AppRoot extends LitElement {
 
       <md-navigation-drawer type="modal">
         <md-list>
-          <md-list-item @click=${() => this.navigate('shopping')}>Lista</md-list-item>
-          <md-list-item @click=${() => this.navigate('config')}>Configuración</md-list-item>
+          <md-list-item @click=${() => this.navigate('/')}>Lista</md-list-item>
+          <md-list-item @click=${() => this.navigate('/config')}>Configuración</md-list-item>
         </md-list>
       </md-navigation-drawer>
 
       <main>
-        ${this.page === 'config'
-          ? html`<config-page></config-page>`
-          : html`<shopping-list></shopping-list>`}
+        <div id="outlet"></div>
       </main>
     `;
   }

--- a/src/ui/config-page.ts
+++ b/src/ui/config-page.ts
@@ -1,5 +1,6 @@
 import { LitElement, html, css } from 'lit';
 import { customElement } from 'lit/decorators.js';
+import { Router } from '@vaadin/router';
 
 @customElement('config-page')
 export class ConfigPage extends LitElement {
@@ -15,8 +16,12 @@ export class ConfigPage extends LitElement {
     }
   `;
 
+  private goHome() {
+    Router.go('/');
+  }
+
   render() {
-    return html`<h1>Configuración</h1>`;
+    return html`<h1>Configuración</h1><button @click=${this.goHome}>Volver</button>`;
   }
 }
 


### PR DESCRIPTION
## Summary
- replace internal page state with Vaadin Router and outlet
- add back button to configuration page via Router
- adjust tests for router-based navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e389e01e48321a9d42ac9083296e4