### PR TITLE
Add section colors and fix side menu

### DIFF
--- a/src/ui/app-root.test.ts
+++ b/src/ui/app-root.test.ts
@@ -17,7 +17,7 @@ if (!customElements.get('md-navigation-drawer')) {
   customElements.define(
     'md-navigation-drawer',
     class extends HTMLElement {
-      open = false;
+      opened = false;
     },
   );
 }
@@ -48,8 +48,8 @@ describe('app-root component', () => {
 
     const drawer = el.shadowRoot?.querySelector(
       'md-navigation-drawer',
-    ) as HTMLElement & { open: boolean };
-    drawer.open = true;
+    ) as HTMLElement & { opened: boolean };
+    drawer.opened = true;
     const items = drawer.querySelectorAll('md-list-item');
     (items[1] as HTMLElement).click();
     await new Promise((r) => setTimeout(r));

--- a/src/ui/app-root.ts
+++ b/src/ui/app-root.ts
@@ -16,6 +16,7 @@ export class AppRoot extends LitElement {
       align-items: center;
       gap: 8px;
       padding: 16px;
+      background-color: #ffcdd2;
     }
 
     .title {
@@ -24,11 +25,16 @@ export class AppRoot extends LitElement {
 
     main {
       padding: 16px;
+      background-color: #c8e6c9;
+    }
+
+    md-navigation-drawer {
+      background-color: #bbdefb;
     }
   `;
 
   @query('md-navigation-drawer')
-  private drawer!: HTMLElement & { open: boolean };
+  private drawer!: HTMLElement & { opened: boolean };
 
   private router!: Router;
 
@@ -42,13 +48,13 @@ export class AppRoot extends LitElement {
     ]);
   }
 
-  private openDrawer() {
-    this.drawer.open = true;
-  }
+  private openDrawer = () => {
+    this.drawer.opened = true;
+  };
 
   private navigate(path: string) {
     Router.go(path);
-    this.drawer.open = false;
+    this.drawer.opened = false;
   }
 
   render() {

--- a/src/ui/config-page.ts
+++ b/src/ui/config-page.ts
@@ -8,6 +8,7 @@ export class ConfigPage extends LitElement {
     :host {
       display: block;
       padding: 16px;
+      background-color: #e1bee7;
     }
 
     h1 {

--- a/src/ui/shopping-list.ts
+++ b/src/ui/shopping-list.ts
@@ -11,6 +11,7 @@ export class ShoppingList extends LitElement {
     :host {
       display: block;
       padding: 16px;
+      background-color: #fff9c4;
     }
   `;
 


### PR DESCRIPTION
## Summary
- add placeholder background colors to main sections for early development
- fix navigation drawer by using the `opened` property and binding the toggle handler

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_688e5396b1ac83219e8272c5aa75812e