### PR TITLE
feat(ui): display environment info in footer

### DIFF
--- a/src/ui/app-root.test.ts
+++ b/src/ui/app-root.test.ts
@@ -39,6 +39,7 @@ declare global {
 
 describe('app-root component', () => {
   beforeEach(() => {
+    import.meta.env.VITE_ENV = 'test';
     window.fetch = async () => new Response('[]', { status: 200 }) as any;
   });
 
@@ -56,5 +57,6 @@ describe('app-root component', () => {
 
     expect(window.location.pathname).toBe('/config');
     expect(el.shadowRoot?.textContent).toContain('Configuración');
+    expect(el.shadowRoot?.textContent).toContain('Env: test');
   });
 });

--- a/src/ui/app-root.ts
+++ b/src/ui/app-root.ts
@@ -25,11 +25,22 @@ export class AppRoot extends LitElement {
 
     main {
       padding: 16px;
+      padding-bottom: 64px;
       background-color: #c8e6c9;
     }
 
     md-navigation-drawer {
       background-color: #bbdefb;
+    }
+
+    footer {
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      padding: 8px 16px;
+      background-color: #eeeeee;
+      box-sizing: border-box;
     }
   `;
 
@@ -37,6 +48,10 @@ export class AppRoot extends LitElement {
   private drawer!: HTMLElement & { opened: boolean };
 
   private router!: Router;
+
+  private get viteEnv(): string {
+    return import.meta.env.VITE_ENV ?? '';
+  }
 
   firstUpdated() {
     this.router = new Router(
@@ -78,6 +93,8 @@ export class AppRoot extends LitElement {
       <main>
         <div id="outlet"></div>
       </main>
+
+      <footer>Env: ${this.viteEnv}</footer>
     `;
   }
 }

--- a/src/ui/shopping-list.ts
+++ b/src/ui/shopping-list.ts
@@ -21,8 +21,6 @@ export class ShoppingList extends LitElement {
   @state()
   private filter = '';
 
-  private readonly viteEnv: string = import.meta.env.VITE_ENV ?? '';
-
   connectedCallback() {
     super.connectedCallback();
     this.load();
@@ -54,7 +52,6 @@ export class ShoppingList extends LitElement {
           </md-list-item>`,
         )}
       </md-list>
-      <div>Env: ${this.viteEnv}</div>
     `;
   }
 }


### PR DESCRIPTION
## Summary
- move environment info to always-visible footer
- clean up shopping list component
- test navigation and footer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e5962a5f48321b8381e527e74ae5c