### PR TITLE
Toggle navigation drawer and overlay menu

### DIFF
--- a/src/ui/app-root.test.ts
+++ b/src/ui/app-root.test.ts
@@ -43,6 +43,23 @@ describe('app-root component', () => {
     window.fetch = async () => new Response('[]', { status: 200 }) as any;
   });
 
+  it('toggles the navigation drawer from the menu button', async () => {
+    const el = await fixture<HTMLDivElement>(html`<app-root></app-root>`);
+    await el.updateComplete;
+
+    const button = el.shadowRoot?.querySelector(
+      'md-icon-button',
+    ) as HTMLElement;
+    const drawer = el.shadowRoot?.querySelector(
+      'md-navigation-drawer',
+    ) as HTMLElement & { opened: boolean };
+
+    button.click();
+    expect(drawer.opened).toBe(true);
+    button.click();
+    expect(drawer.opened).toBe(false);
+  });
+
   it('navigates to config page', async () => {
     const el = await fixture<HTMLDivElement>(html`<app-root></app-root>`);
     await el.updateComplete;

--- a/src/ui/app-root.ts
+++ b/src/ui/app-root.ts
@@ -31,6 +31,11 @@ export class AppRoot extends LitElement {
 
     md-navigation-drawer {
       background-color: #bbdefb;
+      position: fixed;
+      top: 0;
+      left: 0;
+      height: 100%;
+      z-index: 1000;
     }
 
     footer {
@@ -63,8 +68,8 @@ export class AppRoot extends LitElement {
     ]);
   }
 
-  private openDrawer = () => {
-    this.drawer.opened = true;
+  private toggleDrawer = () => {
+    this.drawer.opened = !this.drawer.opened;
   };
 
   private navigate(path: string) {
@@ -75,7 +80,7 @@ export class AppRoot extends LitElement {
   render() {
     return html`
       <header class="top-bar">
-        <md-icon-button @click=${this.openDrawer}>
+        <md-icon-button @click=${this.toggleDrawer}>
           <svg slot="icon" viewBox="0 0 24 24">
             <path d="M3 6h18v2H3V6zm0 5h18v2H3v-2zm0 5h18v2H3v-2z"></path>
           </svg>


### PR DESCRIPTION
## Summary
- allow menu button to both open and close the navigation drawer
- ensure drawer appears above page content
- cover drawer toggle behavior with tests

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688e6400e6b4832183725debfe17d83d