### PR TITLE
feat: add drawer title and close button

### DIFF
--- a/src/ui/app-root.test.ts
+++ b/src/ui/app-root.test.ts
@@ -48,7 +48,7 @@ describe('app-root component', () => {
     await el.updateComplete;
 
     const button = el.shadowRoot?.querySelector(
-      'md-icon-button',
+      'header md-icon-button',
     ) as HTMLElement;
     const drawer = el.shadowRoot?.querySelector(
       'md-navigation-drawer',
@@ -75,5 +75,27 @@ describe('app-root component', () => {
     expect(window.location.pathname).toBe('/config');
     expect(el.shadowRoot?.textContent).toContain('Configuración');
     expect(el.shadowRoot?.textContent).toContain('Env: test');
+  });
+
+  it('closes the navigation drawer from the close button and shows a title', async () => {
+    const el = await fixture<HTMLDivElement>(html`<app-root></app-root>`);
+    await el.updateComplete;
+
+    const menuButton = el.shadowRoot?.querySelector(
+      'header md-icon-button',
+    ) as HTMLElement;
+    const drawer = el.shadowRoot?.querySelector(
+      'md-navigation-drawer',
+    ) as HTMLElement & { opened: boolean };
+
+    menuButton.click();
+    expect(drawer.opened).toBe(true);
+
+    const title = drawer.querySelector('.title') as HTMLElement;
+    expect(title?.textContent).toContain('Menú');
+
+    const closeButton = drawer.querySelector('md-icon-button') as HTMLElement;
+    closeButton.click();
+    expect(drawer.opened).toBe(false);
   });
 });

--- a/src/ui/app-root.ts
+++ b/src/ui/app-root.ts
@@ -38,6 +38,13 @@ export class AppRoot extends LitElement {
       z-index: 1000;
     }
 
+    .drawer-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 16px;
+    }
+
     footer {
       position: fixed;
       bottom: 0;
@@ -89,6 +96,16 @@ export class AppRoot extends LitElement {
       </header>
 
       <md-navigation-drawer type="modal">
+        <div class="drawer-header">
+          <div class="title">Menú</div>
+          <md-icon-button @click=${this.toggleDrawer}>
+            <svg slot="icon" viewBox="0 0 24 24">
+              <path
+                d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+              ></path>
+            </svg>
+          </md-icon-button>
+        </div>
         <md-list>
           <md-list-item @click=${() => this.navigate('/')}>Lista</md-list-item>
           <md-list-item @click=${() => this.navigate('/config')}>Configuración</md-list-item>


### PR DESCRIPTION
## Summary
- add title and close icon button to the navigation drawer
- test closing drawer and presence of title

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688e66dd96888321a43f6e6e27db2147