### PR TITLE
fix: make menu icon visible

### DIFF
--- a/src/ui/app-root.ts
+++ b/src/ui/app-root.ts
@@ -89,7 +89,10 @@ export class AppRoot extends LitElement {
       <header class="top-bar">
         <md-icon-button @click=${this.toggleDrawer}>
           <svg slot="icon" viewBox="0 0 24 24">
-            <path d="M3 6h18v2H3V6zm0 5h18v2H3v-2zm0 5h18v2H3v-2z"></path>
+            <path
+              fill="black"
+              d="M3 6h18v2H3V6zm0 5h18v2H3v-2zm0 5h18v2H3v-2z"
+            ></path>
           </svg>
         </md-icon-button>
         <div class="title">Buy Buddies</div>
@@ -101,6 +104,7 @@ export class AppRoot extends LitElement {
           <md-icon-button @click=${this.toggleDrawer}>
             <svg slot="icon" viewBox="0 0 24 24">
               <path
+                fill="black"
                 d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
               ></path>
             </svg>


### PR DESCRIPTION
## Summary
- set menu and drawer close icons to black for visibility

## Testing
- `npx vitest --run --reporter=basic`


------
https://chatgpt.com/codex/tasks/task_e_688e711f6c8883219d3fed91d6c10b9c