### PR TITLE
fix: make menu icon visible

### DIFF
--- a/src/ui/app-root.ts
+++ b/src/ui/app-root.ts
@@ -45,6 +45,11 @@ export class AppRoot extends LitElement {
       padding: 16px;
     }
 
+    .top-bar md-icon-button,
+    .drawer-header md-icon-button {
+      --md-icon-button-icon-color: black;
+    }
+
     footer {
       position: fixed;
       bottom: 0;


### PR DESCRIPTION
## Summary
- apply shared CSS rule for menu and drawer icon buttons to enforce black icon color without inline styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e711f6c8883219d3fed91d6c10b9c