### PR TITLE
feat: add shopping list table with mock data

### DIFF
--- a/core/shopping/models/shopping-item.ts
+++ b/core/shopping/models/shopping-item.ts
@@ -1,8 +1,10 @@
 export interface ShoppingItem {
   id: string;
   name: string;
+  quantity: string;
+  unit: string;
   group: string;
   category: string;
-  assignedTo?: string;
+  notes?: string;
   bought: boolean;
 }

--- a/core/shopping/use-cases/get-shopping-list.test.ts
+++ b/core/shopping/use-cases/get-shopping-list.test.ts
@@ -6,7 +6,7 @@ describe('getShoppingList', () => {
   it('returns items from repository', async () => {
     const repo = new MockShoppingRepository();
     const items = await getShoppingList(repo);
-    expect(items.length).toBe(2);
-    expect(items[0].name).toBe('Milk');
+    expect(items.length).toBeGreaterThan(100);
+    expect(items[0].name).toBe('Agua fontvella');
   });
 });

--- a/infra/mock/items.ts
+++ b/infra/mock/items.ts
@@ -1,0 +1,1254 @@
+import type { ShoppingItem } from '../../core/shopping/models/shopping-item.js';
+
+export const items: ShoppingItem[] = [
+  {
+    "id": "1",
+    "name": "Agua fontvella",
+    "quantity": "16",
+    "unit": "L",
+    "group": "JM - Juli y Mari",
+    "category": "Bebida",
+    "notes": "2 garrafas de 8L",
+    "bought": false
+  },
+  {
+    "id": "2",
+    "name": "Agua con gas",
+    "quantity": "-",
+    "unit": "-",
+    "group": "PM - Pedro y Marta",
+    "category": "Bebida",
+    "notes": "La cantidad que Pedrito considere",
+    "bought": false
+  },
+  {
+    "id": "3",
+    "name": "Aquarius limón",
+    "quantity": "3",
+    "unit": "L",
+    "group": "JV - Juani y Virgi",
+    "category": "Bebida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "4",
+    "name": "Cerveza",
+    "quantity": "48",
+    "unit": "latas",
+    "group": "CA - Carlos y Ana",
+    "category": "Bebida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "5",
+    "name": "Cerveza",
+    "quantity": "24",
+    "unit": "latas",
+    "group": "CRA - Celi - Ric y Ani",
+    "category": "Bebida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "6",
+    "name": "Cerveza",
+    "quantity": "24",
+    "unit": "latas",
+    "group": "JA - Javi y Alba",
+    "category": "Bebida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "7",
+    "name": "Cerveza",
+    "quantity": "48",
+    "unit": "latas",
+    "group": "PM - Pedro y Marta",
+    "category": "Bebida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "8",
+    "name": "Cerveza 0.0",
+    "quantity": "24",
+    "unit": "latas",
+    "group": "MA - Mangu y Ali",
+    "category": "Bebida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "9",
+    "name": "Cerveza shandy",
+    "quantity": "12",
+    "unit": "latas",
+    "group": "JM - Juli y Mari",
+    "category": "Bebida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "10",
+    "name": "Coca cola zero",
+    "quantity": "4",
+    "unit": "botellas",
+    "group": "RB - Rafa y Bego",
+    "category": "Bebida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "11",
+    "name": "Crema de orujo",
+    "quantity": "2",
+    "unit": "botellas",
+    "group": "JV - Juani y Virgi",
+    "category": "Bebida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "12",
+    "name": "Fanta naranja",
+    "quantity": "2",
+    "unit": "botellas",
+    "group": "JV - Juani y Virgi",
+    "category": "Bebida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "13",
+    "name": "Ginebra (a elegir por Rafael)",
+    "quantity": "1",
+    "unit": "botellas",
+    "group": "RB - Rafa y Bego",
+    "category": "Bebida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "14",
+    "name": "Ginebra 0.0",
+    "quantity": "1",
+    "unit": "botellas",
+    "group": "MA - Mangu y Ali",
+    "category": "Bebida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "15",
+    "name": "Ginebra Tanqueray (Julián)",
+    "quantity": "1",
+    "unit": "botellas",
+    "group": "JM - Juli y Mari",
+    "category": "Bebida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "16",
+    "name": "Licor de hierbas",
+    "quantity": "2",
+    "unit": "botellas",
+    "group": "JV - Juani y Virgi",
+    "category": "Bebida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "17",
+    "name": "Nestea",
+    "quantity": "2",
+    "unit": "botellas",
+    "group": "MA - Mangu y Ali",
+    "category": "Bebida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "18",
+    "name": "Radler 0.0",
+    "quantity": "12",
+    "unit": "latas",
+    "group": "JM - Juli y Mari",
+    "category": "Bebida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "19",
+    "name": "Ron Barceló",
+    "quantity": "2",
+    "unit": "botellas",
+    "group": "RB - Rafa y Bego",
+    "category": "Bebida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "20",
+    "name": "Sprite",
+    "quantity": "3",
+    "unit": "botellas",
+    "group": "JV - Juani y Virgi",
+    "category": "Bebida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "21",
+    "name": "Tinto de verano limón",
+    "quantity": "5",
+    "unit": "botellas",
+    "group": "MA - Mangu y Ali",
+    "category": "Bebida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "22",
+    "name": "Tinto de verano sin alcohol",
+    "quantity": "2",
+    "unit": "botellas",
+    "group": "MA - Mangu y Ali",
+    "category": "Bebida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "23",
+    "name": "Tónica",
+    "quantity": "6",
+    "unit": "botellas",
+    "group": "RB - Rafa y Bego",
+    "category": "Bebida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "24",
+    "name": "Trina limón",
+    "quantity": "2",
+    "unit": "L",
+    "group": "AJ - Almudena y Josemi",
+    "category": "Bebida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "25",
+    "name": "Trina naranja",
+    "quantity": "2",
+    "unit": "L",
+    "group": "AJ - Almudena y Josemi",
+    "category": "Bebida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "26",
+    "name": "Vino blanco y tinto",
+    "quantity": "-",
+    "unit": "botellas",
+    "group": "PM - Pedro y Marta",
+    "category": "Bebida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "27",
+    "name": "Zumo naranja",
+    "quantity": "8",
+    "unit": "L",
+    "group": "AJ - Almudena y Josemi",
+    "category": "Bebida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "28",
+    "name": "Zumo piña",
+    "quantity": "3",
+    "unit": "L",
+    "group": "AJ - Almudena y Josemi",
+    "category": "Bebida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "29",
+    "name": "Bacon hamburguesa",
+    "quantity": "1",
+    "unit": "kg",
+    "group": "JA - Javi y Alba",
+    "category": "Carne y pescado",
+    "notes": "JUEVES ",
+    "bought": false
+  },
+  {
+    "id": "30",
+    "name": "Choricillos",
+    "quantity": "20",
+    "unit": "uds",
+    "group": "JA - Javi y Alba",
+    "category": "Carne y pescado",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "31",
+    "name": "Contramuslos deshuesados",
+    "quantity": "25",
+    "unit": "uds",
+    "group": "JA - Javi y Alba",
+    "category": "Carne y pescado",
+    "notes": "JUEVES ",
+    "bought": false
+  },
+  {
+    "id": "32",
+    "name": "Fuet",
+    "quantity": "6",
+    "unit": "uds",
+    "group": "JA - Javi y Alba",
+    "category": "Carne y pescado",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "33",
+    "name": "Hamburguesas pollo",
+    "quantity": "10",
+    "unit": "uds",
+    "group": "PM - Pedro y Marta",
+    "category": "Carne y pescado",
+    "notes": "JUEVES ",
+    "bought": false
+  },
+  {
+    "id": "34",
+    "name": "Hamburguesas ternera",
+    "quantity": "25",
+    "unit": "uds",
+    "group": "JA - Javi y Alba",
+    "category": "Carne y pescado",
+    "notes": "JUEVES ",
+    "bought": false
+  },
+  {
+    "id": "35",
+    "name": "Jamón de York lonchas",
+    "quantity": "500",
+    "unit": "gr",
+    "group": "CRA - Celi - Ric y Ani",
+    "category": "Carne y pescado",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "36",
+    "name": "Jamón serrano",
+    "quantity": "500",
+    "unit": "gr",
+    "group": "CRA - Celi - Ric y Ani",
+    "category": "Carne y pescado",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "37",
+    "name": "Lomo adobado",
+    "quantity": "10",
+    "unit": "uds",
+    "group": "JA - Javi y Alba",
+    "category": "Carne y pescado",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "38",
+    "name": "Panceta",
+    "quantity": "20",
+    "unit": "uds",
+    "group": "JA - Javi y Alba",
+    "category": "Carne y pescado",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "39",
+    "name": "Pavo lonchas",
+    "quantity": "500",
+    "unit": "gr",
+    "group": "CRA - Celi - Ric y Ani",
+    "category": "Carne y pescado",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "40",
+    "name": "Salchichas frescas",
+    "quantity": "1",
+    "unit": "kg",
+    "group": "JA - Javi y Alba",
+    "category": "Carne y pescado",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "41",
+    "name": "Aguacates",
+    "quantity": "15",
+    "unit": "uds",
+    "group": "JV - Juani y Virgi",
+    "category": "Fruta y verdura",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "42",
+    "name": "Batatas",
+    "quantity": "12",
+    "unit": "uds",
+    "group": "AJ - Almudena y Josemi",
+    "category": "Fruta y verdura",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "43",
+    "name": "Berenjenas",
+    "quantity": "2",
+    "unit": "uds",
+    "group": "AJ - Almudena y Josemi",
+    "category": "Fruta y verdura",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "44",
+    "name": "Calabacines",
+    "quantity": "4",
+    "unit": "uds",
+    "group": "AJ - Almudena y Josemi",
+    "category": "Fruta y verdura",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "45",
+    "name": "Cebollas",
+    "quantity": "1",
+    "unit": "uds",
+    "group": "PE - Polo y Esther",
+    "category": "Fruta y verdura",
+    "notes": "Picadillo Gazpacho. Si son pequeñas que sean 2",
+    "bought": false
+  },
+  {
+    "id": "46",
+    "name": "Cebollas",
+    "quantity": "1",
+    "unit": "kg",
+    "group": "PM - Pedro y Marta",
+    "category": "Fruta y verdura",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "47",
+    "name": "Kiwis",
+    "quantity": "4",
+    "unit": "kg",
+    "group": "PE - Polo y Esther",
+    "category": "Fruta y verdura",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "48",
+    "name": "Lechuga",
+    "quantity": "2",
+    "unit": "uds",
+    "group": "JV - Juani y Virgi",
+    "category": "Fruta y verdura",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "49",
+    "name": "Limones",
+    "quantity": "1",
+    "unit": "kg",
+    "group": "JV - Juani y Virgi",
+    "category": "Fruta y verdura",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "50",
+    "name": "Mangos",
+    "quantity": "6",
+    "unit": "uds",
+    "group": "PE - Polo y Esther",
+    "category": "Fruta y verdura",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "51",
+    "name": "Manzanas",
+    "quantity": "20",
+    "unit": "uds",
+    "group": "PE - Polo y Esther",
+    "category": "Fruta y verdura",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "52",
+    "name": "Melón",
+    "quantity": "2",
+    "unit": "uds",
+    "group": "MA - Mangu y Ali",
+    "category": "Fruta y verdura",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "53",
+    "name": "Patatas grandes",
+    "quantity": "8",
+    "unit": "uds",
+    "group": "PM - Pedro y Marta",
+    "category": "Fruta y verdura",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "54",
+    "name": "Pepinos",
+    "quantity": "1",
+    "unit": "kg",
+    "group": "PE - Polo y Esther",
+    "category": "Fruta y verdura",
+    "notes": "Picadillo Gazpacho",
+    "bought": false
+  },
+  {
+    "id": "55",
+    "name": "Peras",
+    "quantity": "20",
+    "unit": "uds",
+    "group": "PE - Polo y Esther",
+    "category": "Fruta y verdura",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "56",
+    "name": "Pimiento rojo",
+    "quantity": "2",
+    "unit": "uds",
+    "group": "PE - Polo y Esther",
+    "category": "Fruta y verdura",
+    "notes": "Picadillo Gazpacho",
+    "bought": false
+  },
+  {
+    "id": "57",
+    "name": "Pimiento verde italiano",
+    "quantity": "3",
+    "unit": "uds",
+    "group": "PE - Polo y Esther",
+    "category": "Fruta y verdura",
+    "notes": "Picadillo Gazpacho",
+    "bought": false
+  },
+  {
+    "id": "58",
+    "name": "Plátanos",
+    "quantity": "20",
+    "unit": "uds",
+    "group": "PE - Polo y Esther",
+    "category": "Fruta y verdura",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "59",
+    "name": "Sandía",
+    "quantity": "2",
+    "unit": "uds",
+    "group": "MA - Mangu y Ali",
+    "category": "Fruta y verdura",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "60",
+    "name": "Tomates",
+    "quantity": "6",
+    "unit": "kg",
+    "group": "JV - Juani y Virgi",
+    "category": "Fruta y verdura",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "61",
+    "name": "Zanahorias",
+    "quantity": "1",
+    "unit": "kg",
+    "group": "JV - Juani y Virgi",
+    "category": "Fruta y verdura",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "62",
+    "name": "Comida jueves GF",
+    "quantity": "-",
+    "unit": "-",
+    "group": "MA - Mangu y Ali",
+    "category": "Gluten Free",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "63",
+    "name": "Dulce GF",
+    "quantity": "-",
+    "unit": "-",
+    "group": "MA - Mangu y Ali",
+    "category": "Gluten Free",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "64",
+    "name": "Pan de hamburguesa GF",
+    "quantity": "2",
+    "unit": "uds",
+    "group": "MA - Mangu y Ali",
+    "category": "Gluten Free",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "65",
+    "name": "Pan GF",
+    "quantity": "-",
+    "unit": "-",
+    "group": "MA - Mangu y Ali",
+    "category": "Gluten Free",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "66",
+    "name": "Tostaditas GF",
+    "quantity": "-",
+    "unit": "-",
+    "group": "MA - Mangu y Ali",
+    "category": "Gluten Free",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "67",
+    "name": "Leche avena",
+    "quantity": "3",
+    "unit": "bricks",
+    "group": "CRA - Celi - Ric y Ani",
+    "category": "Lácteos/quesos",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "68",
+    "name": "Leche desnatada sin lactosa",
+    "quantity": "1",
+    "unit": "bricks",
+    "group": "CRA - Celi - Ric y Ani",
+    "category": "Lácteos/quesos",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "69",
+    "name": "Leche entera",
+    "quantity": "6",
+    "unit": "bricks",
+    "group": "JM - Juli y Mari",
+    "category": "Lácteos/quesos",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "70",
+    "name": "Leche semi",
+    "quantity": "12",
+    "unit": "bricks",
+    "group": "JM - Juli y Mari",
+    "category": "Lácteos/quesos",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "71",
+    "name": "Oikos",
+    "quantity": "4",
+    "unit": "uds",
+    "group": "AJ - Almudena y Josemi",
+    "category": "Lácteos/quesos",
+    "notes": "Stracciatella (para Virginia)",
+    "bought": false
+  },
+  {
+    "id": "72",
+    "name": "Queso cuña",
+    "quantity": "-",
+    "unit": "-",
+    "group": "CRA - Celi - Ric y Ani",
+    "category": "Lácteos/quesos",
+    "notes": "Pasteurizado",
+    "bought": false
+  },
+  {
+    "id": "73",
+    "name": "Queso lonchas hamburguesa",
+    "quantity": "35",
+    "unit": "uds",
+    "group": "CRA - Celi - Ric y Ani",
+    "category": "Lácteos/quesos",
+    "notes": "Pasteurizado",
+    "bought": false
+  },
+  {
+    "id": "74",
+    "name": "Queso rallado",
+    "quantity": "1",
+    "unit": "uds",
+    "group": "PM - Pedro y Marta",
+    "category": "Lácteos/quesos",
+    "notes": "Pasteurizado",
+    "bought": false
+  },
+  {
+    "id": "75",
+    "name": "Yogures",
+    "quantity": "16",
+    "unit": "uds",
+    "group": "AJ - Almudena y Josemi",
+    "category": "Lácteos/quesos",
+    "notes": "Natural y económicos para niños... y mete alguno más que Rafa desayunará alguno jeje",
+    "bought": false
+  },
+  {
+    "id": "76",
+    "name": "Aceite",
+    "quantity": "2",
+    "unit": "L",
+    "group": "RB - Rafa y Bego",
+    "category": "Otros",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "77",
+    "name": "Azúcar moreno",
+    "quantity": "1",
+    "unit": "kg",
+    "group": "RB - Rafa y Bego",
+    "category": "Otros",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "78",
+    "name": "Bollos desayuno",
+    "quantity": "-",
+    "unit": "-",
+    "group": "RB - Rafa y Bego",
+    "category": "Otros",
+    "notes": "A elegir por Bego",
+    "bought": false
+  },
+  {
+    "id": "79",
+    "name": "Café",
+    "quantity": "4",
+    "unit": "botes",
+    "group": "RB - Rafa y Bego",
+    "category": "Otros",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "80",
+    "name": "Café descafeinado",
+    "quantity": "1",
+    "unit": "botes",
+    "group": "RB - Rafa y Bego",
+    "category": "Otros",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "81",
+    "name": "Café To Go",
+    "quantity": "-",
+    "unit": "-",
+    "group": "JV - Juani y Virgi",
+    "category": "Otros",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "82",
+    "name": "Chocolate",
+    "quantity": "2",
+    "unit": "tabletas",
+    "group": "RB - Rafa y Bego",
+    "category": "Otros",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "83",
+    "name": "Chuches",
+    "quantity": "",
+    "unit": "",
+    "group": "CRA - Celi - Ric y Ani",
+    "category": "Otros",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "84",
+    "name": "Hielo",
+    "quantity": "5",
+    "unit": "bolsas",
+    "group": "RB - Rafa y Bego",
+    "category": "Otros",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "85",
+    "name": "Hielo (como veas para enfriar)",
+    "quantity": "-",
+    "unit": "-",
+    "group": "JA - Javi y Alba",
+    "category": "Otros",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "86",
+    "name": "Hielo (cuando llegue Pedro el viernes)",
+    "quantity": "-",
+    "unit": "-",
+    "group": "PM - Pedro y Marta",
+    "category": "Otros",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "87",
+    "name": "Panela",
+    "quantity": "-",
+    "unit": "-",
+    "group": "CRA - Celi - Ric y Ani",
+    "category": "Otros",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "88",
+    "name": "Papel de aluminio y film transparente",
+    "quantity": "-",
+    "unit": "-",
+    "group": "PM - Pedro y Marta",
+    "category": "Otros",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "89",
+    "name": "Papel de cocina",
+    "quantity": "6",
+    "unit": "rollos",
+    "group": "JM - Juli y Mari",
+    "category": "Otros",
+    "notes": "3x Grandes o 6x normales",
+    "bought": false
+  },
+  {
+    "id": "90",
+    "name": "Papel higiénico",
+    "quantity": "18",
+    "unit": "rollos",
+    "group": "JM - Juli y Mari",
+    "category": "Otros",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "91",
+    "name": "Roibos cítricos (Mercadona)",
+    "quantity": "1",
+    "unit": "caja",
+    "group": "PE - Polo y Esther",
+    "category": "Otros",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "92",
+    "name": "Sacarina",
+    "quantity": "-",
+    "unit": "-",
+    "group": "RB - Rafa y Bego",
+    "category": "Otros",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "93",
+    "name": "Sal",
+    "quantity": "1",
+    "unit": "kg",
+    "group": "RB - Rafa y Bego",
+    "category": "Otros",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "94",
+    "name": "Té frío piña colada (mercadona)",
+    "quantity": "-",
+    "unit": "-",
+    "group": "PE - Polo y Esther",
+    "category": "Otros",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "95",
+    "name": "Té rojo",
+    "quantity": "-",
+    "unit": "-",
+    "group": "PE - Polo y Esther",
+    "category": "Otros",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "96",
+    "name": "Té sen (mercadona)",
+    "quantity": "-",
+    "unit": "-",
+    "group": "PE - Polo y Esther",
+    "category": "Otros",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "97",
+    "name": "Té verde",
+    "quantity": "-",
+    "unit": "-",
+    "group": "PE - Polo y Esther",
+    "category": "Otros",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "98",
+    "name": "Vasos",
+    "quantity": "-",
+    "unit": "-",
+    "group": "JM - Juli y Mari",
+    "category": "Otros",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "99",
+    "name": "Vermouth",
+    "quantity": "-",
+    "unit": "-",
+    "group": "CRA - Celi - Ric y Ani",
+    "category": "Bebida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "100",
+    "name": "Vinagre",
+    "quantity": "1",
+    "unit": "L",
+    "group": "RB - Rafa y Bego",
+    "category": "Otros",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "101",
+    "name": "Atún",
+    "quantity": "12",
+    "unit": "latas",
+    "group": "PM - Pedro y Marta",
+    "category": "Resto comida",
+    "notes": "2 paquetes de 6 latas",
+    "bought": false
+  },
+  {
+    "id": "102",
+    "name": "Empanadas",
+    "quantity": "2",
+    "unit": "uds",
+    "group": "RB - Rafa y Bego",
+    "category": "Resto comida",
+    "notes": "Panadería Corralejo Navaluenga - 3 empanadas encargadas - 15 euros cada una - Cierran antes de las 14h",
+    "bought": false
+  },
+  {
+    "id": "103",
+    "name": "Frutos rojos - arándanos - fresas",
+    "quantity": "-",
+    "unit": "-",
+    "group": "JM - Juli y Mari",
+    "category": "Resto comida",
+    "notes": "Para desayuno",
+    "bought": false
+  },
+  {
+    "id": "104",
+    "name": "Gazpacho",
+    "quantity": "4",
+    "unit": "L",
+    "group": "JA - Javi y Alba",
+    "category": "Resto comida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "105",
+    "name": "Guacamole",
+    "quantity": "3",
+    "unit": "uds",
+    "group": "CRA - Celi - Ric y Ani",
+    "category": "Resto comida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "106",
+    "name": "Huevos",
+    "quantity": "24",
+    "unit": "uds",
+    "group": "JM - Juli y Mari",
+    "category": "Resto comida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "107",
+    "name": "Humus",
+    "quantity": "3",
+    "unit": "uds",
+    "group": "CRA - Celi - Ric y Ani",
+    "category": "Resto comida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "108",
+    "name": "Jamon en taquitos",
+    "quantity": "3",
+    "unit": "uds",
+    "group": "JA - Javi y Alba",
+    "category": "Resto comida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "109",
+    "name": "Ketchup",
+    "quantity": "2",
+    "unit": "botes",
+    "group": "CA - Carlos y Ana",
+    "category": "Resto comida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "110",
+    "name": "Mayonesa",
+    "quantity": "2",
+    "unit": "botes",
+    "group": "CA - Carlos y Ana",
+    "category": "Resto comida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "111",
+    "name": "Mostaza",
+    "quantity": "1",
+    "unit": "botes",
+    "group": "CA - Carlos y Ana",
+    "category": "Resto comida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "112",
+    "name": "Nachos",
+    "quantity": "-",
+    "unit": "-",
+    "group": "PE - Polo y Esther",
+    "category": "Resto comida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "113",
+    "name": "Más nachos",
+    "quantity": "6",
+    "unit": "bolsas",
+    "group": "PM - Pedro y Marta",
+    "category": "Resto comida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "114",
+    "name": "Pan (cena jueves)",
+    "quantity": "-",
+    "unit": "-",
+    "group": "RB - Rafa y Bego",
+    "category": "Resto comida",
+    "notes": "4 barras o 3 hogazas - y alguna integral",
+    "bought": false
+  },
+  {
+    "id": "115",
+    "name": "Pan (viernes)",
+    "quantity": "-",
+    "unit": "-",
+    "group": "PM - Pedro y Marta",
+    "category": "Resto comida",
+    "notes": "6 barras o 4 hogazas - y alguna integral",
+    "bought": false
+  },
+  {
+    "id": "116",
+    "name": "Pan de molde espelta",
+    "quantity": "3",
+    "unit": "uds",
+    "group": "PE - Polo y Esther",
+    "category": "Resto comida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "117",
+    "name": "Pan hamburguesa brioche/cristal",
+    "quantity": "35",
+    "unit": "uds",
+    "group": "CA - Carlos y Ana",
+    "category": "Resto comida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "118",
+    "name": "Pan para tostadas",
+    "quantity": "5",
+    "unit": "uds",
+    "group": "PE - Polo y Esther",
+    "category": "Resto comida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "119",
+    "name": "Pasta",
+    "quantity": "1",
+    "unit": "kg",
+    "group": "PM - Pedro y Marta",
+    "category": "Resto comida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "120",
+    "name": "Pepinillos hamburguesa",
+    "quantity": "-",
+    "unit": "-",
+    "group": "AJ - Almudena y Josemi",
+    "category": "Resto comida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "121",
+    "name": "Picatostes",
+    "quantity": "-",
+    "unit": "-",
+    "group": "JA - Javi y Alba",
+    "category": "Resto comida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "122",
+    "name": "Picoteo",
+    "quantity": "-",
+    "unit": "-",
+    "group": "CRA - Celi - Ric y Ani",
+    "category": "Resto comida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "123",
+    "name": "Salmorejo",
+    "quantity": "4",
+    "unit": "L",
+    "group": "JA - Javi y Alba",
+    "category": "Resto comida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "124",
+    "name": "Tomate frito",
+    "quantity": "2",
+    "unit": "botes",
+    "group": "PM - Pedro y Marta",
+    "category": "Resto comida",
+    "notes": "",
+    "bought": false
+  },
+  {
+    "id": "125",
+    "name": "Vinagreo",
+    "quantity": "-",
+    "unit": "-",
+    "group": "AJ - Almudena y Josemi",
+    "category": "Resto comida",
+    "notes": "",
+    "bought": false
+  }
+];

--- a/infra/mock/shopping-repository.ts
+++ b/infra/mock/shopping-repository.ts
@@ -1,24 +1,6 @@
 import type { ShoppingRepository } from '../../core/shopping/ports/shopping-repository.js';
 import type { ShoppingItem } from '../../core/shopping/models/shopping-item.js';
-
-const items: ShoppingItem[] = [
-  {
-    id: '1',
-    name: 'Milk',
-    group: 'Kitchen',
-    category: 'Dairy',
-    assignedTo: 'Alice',
-    bought: false,
-  },
-  {
-    id: '2',
-    name: 'Bread',
-    group: 'Kitchen',
-    category: 'Bakery',
-    assignedTo: 'Bob',
-    bought: true,
-  },
-];
+import { items } from './items.js';
 
 export class MockShoppingRepository implements ShoppingRepository {
   async getItems(): Promise<ShoppingItem[]> {

--- a/src/ui/shopping-list.test.ts
+++ b/src/ui/shopping-list.test.ts
@@ -1,43 +1,38 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { fixture, html } from '@open-wc/testing';
 import { vi } from 'vitest';
 
 vi.mock('@material/web/textfield/outlined-text-field.js', () => ({}));
-vi.mock('@material/web/list/list.js', () => ({}));
-vi.mock('@material/web/list/list-item.js', () => ({}));
 
 import './shopping-list.js';
 
 if (!customElements.get('md-outlined-text-field')) {
   customElements.define('md-outlined-text-field', class extends HTMLElement {});
 }
-if (!customElements.get('md-list')) {
-  customElements.define('md-list', class extends HTMLElement {});
-}
-if (!customElements.get('md-list-item')) {
-  customElements.define('md-list-item', class extends HTMLElement {});
-}
-
-declare global {
-  interface Window {
-    fetch: typeof fetch;
-  }
-}
 
 describe('shopping-list component', () => {
-  beforeEach(() => {
-    window.fetch = async () =>
-      new Response(
-        JSON.stringify([
-          { id: '1', name: 'Water', group: '', category: 'Drinks', bought: false },
-        ]),
-        { status: 200 },
-      ) as any;
-  });
-
   it('renders items', async () => {
-    const el = await fixture<HTMLDivElement>(html`<shopping-list></shopping-list>`);
+    window.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify([]), { status: 200 }),
+    ) as any;
+    const el = await fixture<any>(html`<shopping-list></shopping-list>`);
     await el.updateComplete;
-    expect(el.shadowRoot?.textContent).toContain('Water');
+    el.items = [
+      {
+        id: '1',
+        name: 'Water',
+        quantity: '1',
+        unit: 'L',
+        group: '',
+        category: 'Drinks',
+        notes: '',
+        bought: false,
+      },
+    ];
+    await el.updateComplete;
+    await new Promise((r) => setTimeout(r));
+    const table = el.shadowRoot!.querySelector('shopping-table') as any;
+    await table.updateComplete;
+    expect(table.shadowRoot.textContent).toContain('Water');
   });
 });

--- a/src/ui/shopping-list.ts
+++ b/src/ui/shopping-list.ts
@@ -1,8 +1,7 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@material/web/textfield/outlined-text-field.js';
-import '@material/web/list/list.js';
-import '@material/web/list/list-item.js';
+import './shopping-table.js';
 import type { ShoppingItem } from '../../core/shopping/models/shopping-item.js';
 
 @customElement('shopping-list')
@@ -44,14 +43,7 @@ export class ShoppingList extends LitElement {
         label="Search"
         @input=${this.onSearch}
       ></md-outlined-text-field>
-      <md-list>
-        ${filtered.map(
-          (item) => html`<md-list-item>
-            ${item.name} - ${item.category}
-            ${item.bought ? '✔️' : ''}
-          </md-list-item>`,
-        )}
-      </md-list>
+      <shopping-table .items=${filtered}></shopping-table>
     `;
   }
 }

--- a/src/ui/shopping-row.test.ts
+++ b/src/ui/shopping-row.test.ts
@@ -1,0 +1,26 @@
+import { fixture, html } from '@open-wc/testing';
+import { describe, it, expect } from 'vitest';
+import './shopping-row.js';
+
+import type { ShoppingItem } from '../../core/shopping/models/shopping-item.js';
+
+describe('shopping-row', () => {
+  it('renders item fields', async () => {
+    const item: ShoppingItem = {
+      id: '1',
+      name: 'Agua',
+      quantity: '1',
+      unit: 'L',
+      group: 'Grupo',
+      category: 'Bebida',
+      notes: 'Nota',
+      bought: false,
+    };
+    const row = await fixture<any>(html`<shopping-row></shopping-row>`);
+    row.item = item;
+    await row.updateComplete;
+    expect(row.textContent).toContain('Agua');
+    expect(row.textContent).toContain('1');
+    expect(row.textContent).toContain('Nota');
+  });
+});

--- a/src/ui/shopping-row.ts
+++ b/src/ui/shopping-row.ts
@@ -1,0 +1,44 @@
+import { LitElement, html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import type { ShoppingItem } from '../../core/shopping/models/shopping-item.js';
+
+@customElement('shopping-row')
+export class ShoppingRow extends LitElement {
+  createRenderRoot() {
+    return this;
+  }
+
+  static styles = css`
+    :host {
+      display: contents;
+    }
+    td {
+      padding: 4px;
+      border: 1px solid #ccc;
+    }
+  `;
+
+  @property({ type: Object })
+  item!: ShoppingItem;
+
+  render() {
+    if (!this.item) {
+      return html``;
+    }
+    const { name, quantity, unit, group, category, notes } = this.item;
+    return html`<tr>
+      <td>${name}</td>
+      <td>${quantity}</td>
+      <td>${unit}</td>
+      <td>${group}</td>
+      <td>${category}</td>
+      <td>${notes}</td>
+    </tr>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'shopping-row': ShoppingRow;
+  }
+}

--- a/src/ui/shopping-table.test.ts
+++ b/src/ui/shopping-table.test.ts
@@ -1,0 +1,21 @@
+import { fixture, html } from '@open-wc/testing';
+import { describe, it, expect } from 'vitest';
+import './shopping-table.js';
+
+import type { ShoppingItem } from '../../core/shopping/models/shopping-item.js';
+
+describe('shopping-table', () => {
+  it('renders rows for items', async () => {
+    const items: ShoppingItem[] = [
+      { id: '1', name: 'Agua', quantity: '1', unit: 'L', group: 'G', category: 'Bebida', notes: '', bought: false },
+      { id: '2', name: 'Pan', quantity: '2', unit: 'uds', group: 'G', category: 'Resto', notes: '', bought: false },
+    ];
+    const el = await fixture<any>(html`<shopping-table></shopping-table>`);
+    el.items = items;
+    await el.updateComplete;
+    await new Promise((r) => setTimeout(r));
+    const rows = el.shadowRoot!.querySelectorAll('shopping-row');
+    expect(rows.length).toBe(2);
+    expect(el.shadowRoot!.textContent).toContain('Agua');
+  });
+});

--- a/src/ui/shopping-table.ts
+++ b/src/ui/shopping-table.ts
@@ -1,0 +1,46 @@
+import { LitElement, html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import type { ShoppingItem } from '../../core/shopping/models/shopping-item.js';
+import './shopping-row.js';
+
+@customElement('shopping-table')
+export class ShoppingTable extends LitElement {
+  static styles = css`
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    th {
+      text-align: left;
+      padding: 4px;
+      border-bottom: 2px solid #000;
+    }
+  `;
+
+  @property({ type: Array })
+  items: ShoppingItem[] = [];
+
+  render() {
+    return html`<table>
+      <thead>
+        <tr>
+          <th>Producto</th>
+          <th>Cantidad</th>
+          <th>Unidad</th>
+          <th>Grupo</th>
+          <th>Categoría</th>
+          <th>Notas</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${this.items.map((item) => html`<shopping-row .item=${item}></shopping-row>`)}
+      </tbody>
+    </table>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'shopping-table': ShoppingTable;
+  }
+}


### PR DESCRIPTION
## Summary
- extend shopping item model to include quantity, unit and notes
- serve extensive mock shopping list and display it in a table with row components
- add unit tests for listing, table and row components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e92cc18748321877c38ccc73324c3