### PR TITLE
feat: configure google sheet from UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,9 @@ BuyBuddies is a collaborative shopping list app built with TypeScript, following
 3. Start Vercel development server (if needed): `vercel dev`
 
 Environment variables are required for Google Sheets access:
-`GOOGLE_SHEET_ID`, `GOOGLE_SERVICE_ACCOUNT_EMAIL`, `GOOGLE_PRIVATE_KEY`, `USE_MOCK_REPO`.
+`GOOGLE_SERVICE_ACCOUNT_EMAIL`, `GOOGLE_PRIVATE_KEY`.
+
+The Google Sheet ID is configured in the app's settings page and stored in
+`localStorage`. If no ID is provided, the application will use a mock
+repository.
 

--- a/api/shopping/get.ts
+++ b/api/shopping/get.ts
@@ -2,14 +2,19 @@ import { getShoppingList } from '../../core/shopping/use-cases/get-shopping-list
 import { GoogleSheetsShoppingRepository } from '../../infra/google-sheets/shopping-repository.js';
 import { MockShoppingRepository } from '../../infra/mock/shopping-repository.js';
 
+interface Request {
+  query?: { googleSheetId?: string };
+}
+
 interface Response {
   status(code: number): { json(body: unknown): void };
 }
 
-export default async function handler(_req: unknown, res: Response) {
-  const repo = process.env.USE_MOCK_REPO
-    ? new MockShoppingRepository()
-    : new GoogleSheetsShoppingRepository();
+export default async function handler(req: Request, res: Response) {
+  const googleSheetId = req.query?.googleSheetId;
+  const repo = googleSheetId
+    ? new GoogleSheetsShoppingRepository(googleSheetId)
+    : new MockShoppingRepository();
   const items = await getShoppingList(repo);
   res.status(200).json(items);
 }

--- a/infra/google-sheets/shopping-repository.ts
+++ b/infra/google-sheets/shopping-repository.ts
@@ -4,16 +4,15 @@ import type { ShoppingRepository } from '../../core/shopping/ports/shopping-repo
 import type { ShoppingItem } from '../../core/shopping/models/shopping-item.js';
 
 export class GoogleSheetsShoppingRepository implements ShoppingRepository {
+  constructor(private sheetId: string) {}
+
   async getItems(): Promise<ShoppingItem[]> {
     const auth = new JWT({
       email: process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL as string,
       key: (process.env.GOOGLE_PRIVATE_KEY as string).replace(/\\n/g, '\n'),
       scopes: ['https://www.googleapis.com/auth/spreadsheets'],
     });
-    const doc = new GoogleSpreadsheet(
-      process.env.GOOGLE_SHEET_ID as string,
-      auth,
-    );
+    const doc = new GoogleSpreadsheet(this.sheetId, auth);
     await doc.loadInfo();
     const sheet = doc.sheetsByIndex[0]!;
     const rows = await sheet.getRows();

--- a/src/ui/app-root.test.ts
+++ b/src/ui/app-root.test.ts
@@ -41,6 +41,7 @@ describe('app-root component', () => {
   beforeEach(() => {
     import.meta.env.VITE_ENV = 'test';
     window.fetch = async () => new Response('[]', { status: 200 }) as any;
+    localStorage.clear();
   });
 
   it('toggles the navigation drawer from the menu button', async () => {

--- a/src/ui/config-page.test.ts
+++ b/src/ui/config-page.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { fixture, html } from '@open-wc/testing';
+import { vi } from 'vitest';
+
+vi.mock('@material/web/textfield/outlined-text-field.js', () => ({}));
+
+import './config-page.js';
+
+if (!customElements.get('md-outlined-text-field')) {
+  customElements.define(
+    'md-outlined-text-field',
+    class extends HTMLElement {
+      value = '';
+    },
+  );
+}
+
+describe('config-page component', () => {
+  it('stores googleSheetId in localStorage', async () => {
+    localStorage.clear();
+    localStorage.setItem('googleSheetId', 'initial');
+    const el = await fixture<any>(html`<config-page></config-page>`);
+    await el.updateComplete;
+    const input = el.shadowRoot!.querySelector('md-outlined-text-field') as any;
+    expect(input.value).toBe('initial');
+    input.value = 'new-id';
+    input.dispatchEvent(new Event('input'));
+    expect(localStorage.getItem('googleSheetId')).toBe('new-id');
+  });
+});

--- a/src/ui/config-page.ts
+++ b/src/ui/config-page.ts
@@ -1,6 +1,7 @@
 import { LitElement, html, css } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, state } from 'lit/decorators.js';
 import { Router } from '@vaadin/router';
+import '@material/web/textfield/outlined-text-field.js';
 
 @customElement('config-page')
 export class ConfigPage extends LitElement {
@@ -17,12 +18,33 @@ export class ConfigPage extends LitElement {
     }
   `;
 
+  @state()
+  private googleSheetId = '';
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.googleSheetId = localStorage.getItem('googleSheetId') ?? '';
+  }
+
+  private onInput(e: Event) {
+    this.googleSheetId = (e.target as HTMLInputElement).value;
+    localStorage.setItem('googleSheetId', this.googleSheetId);
+  }
+
   private goHome() {
     Router.go('/');
   }
 
   render() {
-    return html`<h1>Configuración</h1><button @click=${this.goHome}>Volver</button>`;
+    return html`
+      <h1>Configuración</h1>
+      <md-outlined-text-field
+        label="Google Sheet ID"
+        .value=${this.googleSheetId}
+        @input=${this.onInput}
+      ></md-outlined-text-field>
+      <button @click=${this.goHome}>Volver</button>
+    `;
   }
 }
 

--- a/src/ui/shopping-list.test.ts
+++ b/src/ui/shopping-list.test.ts
@@ -12,6 +12,7 @@ if (!customElements.get('md-outlined-text-field')) {
 
 describe('shopping-list component', () => {
   it('renders items', async () => {
+    localStorage.clear();
     window.fetch = vi.fn().mockResolvedValue(
       new Response(JSON.stringify([]), { status: 200 }),
     ) as any;

--- a/src/ui/shopping-list.ts
+++ b/src/ui/shopping-list.ts
@@ -26,7 +26,11 @@ export class ShoppingList extends LitElement {
   }
 
   async load() {
-    const res = await fetch('/api/shopping/get');
+    const sheetId = localStorage.getItem('googleSheetId');
+    const url = sheetId
+      ? `/api/shopping/get?googleSheetId=${encodeURIComponent(sheetId)}`
+      : '/api/shopping/get';
+    const res = await fetch(url);
     this.items = await res.json();
   }
 


### PR DESCRIPTION
## Summary
- move Google Sheet ID to config page and local storage
- pass sheet ID to API via query param and default to mock repository
- document new setup and add tests

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688f15598a948321926882c555c5b453