### PR TITLE
fix table rows rendering

### DIFF
--- a/src/ui/shopping-row.ts
+++ b/src/ui/shopping-row.ts
@@ -26,14 +26,14 @@ export class ShoppingRow extends LitElement {
       return html``;
     }
     const { name, quantity, unit, group, category, notes } = this.item;
-    return html`<tr>
+    return html`
       <td>${name}</td>
       <td>${quantity}</td>
       <td>${unit}</td>
       <td>${group}</td>
       <td>${category}</td>
       <td>${notes}</td>
-    </tr>`;
+    `;
   }
 }
 

--- a/src/ui/shopping-table.ts
+++ b/src/ui/shopping-table.ts
@@ -1,4 +1,5 @@
 import { LitElement, html, css } from 'lit';
+import { repeat } from 'lit/directives/repeat.js';
 import { customElement, property } from 'lit/decorators.js';
 import type { ShoppingItem } from '../../core/shopping/models/shopping-item.js';
 import './shopping-row.js';
@@ -33,7 +34,11 @@ export class ShoppingTable extends LitElement {
         </tr>
       </thead>
       <tbody>
-        ${this.items.map((item) => html`<shopping-row .item=${item}></shopping-row>`)}
+        ${repeat(
+          this.items,
+          (item) => item.id,
+          (item) => html`<tr><shopping-row .item=${item}></shopping-row></tr>`
+        )}
       </tbody>
     </table>`;
   }


### PR DESCRIPTION
## Summary
- ensure each shopping item renders within its own table row
- render shopping-row as a set of table cells for correct column alignment
- key table rows using Lit's repeat directive for stable rendering

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688f3615f6348321a75557bf648721ae