### PR TITLE
Display total and filtered product counts in shopping list

### DIFF
--- a/src/ui/shopping-list.test.ts
+++ b/src/ui/shopping-list.test.ts
@@ -29,7 +29,19 @@ describe('shopping-list component', () => {
         notes: '',
         bought: false,
       },
+      {
+        id: '2',
+        name: 'Milk',
+        quantity: '1',
+        unit: 'L',
+        group: '',
+        category: 'Dairy',
+        notes: '',
+        bought: false,
+      },
     ];
+    await el.updateComplete;
+    (el as any).filter = 'water';
     await el.updateComplete;
     await new Promise((r) => setTimeout(r));
     const items = el.shadowRoot!.querySelectorAll('shopping-item');
@@ -37,5 +49,7 @@ describe('shopping-list component', () => {
     const item = items[0] as any;
     await item.updateComplete;
     expect(item.shadowRoot!.textContent).toContain('Water');
+    const total = el.shadowRoot!.querySelector('.total')!;
+    expect(total.textContent).toContain('Total de productos: 1 de 2');
   });
 });

--- a/src/ui/shopping-list.ts
+++ b/src/ui/shopping-list.ts
@@ -48,6 +48,9 @@ export class ShoppingList extends LitElement {
         label="Search"
         @input=${this.onSearch}
       ></md-outlined-text-field>
+      <div class="total">
+        Total de productos: ${filtered.length} de ${this.items.length}
+      </div>
       <div>
         ${repeat(
           filtered,


### PR DESCRIPTION
## Summary
- display both filtered and overall product totals above the shopping list
- test product counts reflect filtered and overall totals

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688f54f1ebec832199f0d16c83e95be3