### PR TITLE
feat: add frontend internationalization

### DIFF
--- a/src/ui/app-root.test.ts
+++ b/src/ui/app-root.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { fixture, html } from '@open-wc/testing';
 import { vi } from 'vitest';
+import { setLang } from './i18n.js';
 
 vi.mock('@material/web/iconbutton/icon-button.js', () => ({}));
 vi.mock('@material/web/labs/navigationdrawer/navigation-drawer.js', () => ({}));
@@ -42,6 +43,7 @@ describe('app-root component', () => {
     import.meta.env.VITE_ENV = 'test';
     window.fetch = async () => new Response('[]', { status: 200 }) as any;
     localStorage.clear();
+    setLang('es');
   });
 
   it('toggles the navigation drawer from the menu button', async () => {
@@ -76,6 +78,15 @@ describe('app-root component', () => {
     expect(window.location.pathname).toBe('/config');
     expect(el.shadowRoot?.textContent).toContain('Configuración');
     expect(el.shadowRoot?.textContent).toContain('Env: test');
+  });
+
+  it('renders english texts when language is set', async () => {
+    setLang('en');
+    const el = await fixture<HTMLDivElement>(html`<app-root></app-root>`);
+    await el.updateComplete;
+    const text = el.shadowRoot?.textContent || '';
+    expect(text).toContain('Menu');
+    expect(text).toContain('Settings');
   });
 
   it('closes the navigation drawer from the close button and shows a title', async () => {

--- a/src/ui/app-root.ts
+++ b/src/ui/app-root.ts
@@ -7,6 +7,7 @@ import '@material/web/list/list.js';
 import '@material/web/list/list-item.js';
 import './shopping-list.js';
 import './config-page.js';
+import { t, LangController } from './i18n.js';
 
 @customElement('app-root')
 export class AppRoot extends LitElement {
@@ -65,6 +66,7 @@ export class AppRoot extends LitElement {
   private drawer!: HTMLElement & { opened: boolean };
 
   private router!: Router;
+  private lang = new LangController(this);
 
   private get viteEnv(): string {
     return import.meta.env.VITE_ENV ?? '';
@@ -102,7 +104,7 @@ export class AppRoot extends LitElement {
 
       <md-navigation-drawer type="modal">
         <div class="drawer-header">
-          <div class="title">Menú</div>
+          <div class="title">${t('menu')}</div>
           <md-icon-button @click=${this.toggleDrawer}>
             <svg slot="icon" viewBox="0 0 24 24">
               <path
@@ -112,8 +114,10 @@ export class AppRoot extends LitElement {
           </md-icon-button>
         </div>
         <md-list>
-          <md-list-item @click=${() => this.navigate('/')}>Lista</md-list-item>
-          <md-list-item @click=${() => this.navigate('/config')}>Configuración</md-list-item>
+          <md-list-item @click=${() => this.navigate('/')}
+            >${t('list')}</md-list-item>
+          <md-list-item @click=${() => this.navigate('/config')}
+            >${t('config')}</md-list-item>
         </md-list>
       </md-navigation-drawer>
 

--- a/src/ui/config-page.test.ts
+++ b/src/ui/config-page.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { fixture, html } from '@open-wc/testing';
 import { vi } from 'vitest';
+import { setLang } from './i18n.js';
 
 vi.mock('@material/web/textfield/outlined-text-field.js', () => ({}));
 
@@ -16,6 +17,10 @@ if (!customElements.get('md-outlined-text-field')) {
 }
 
 describe('config-page component', () => {
+  beforeEach(() => {
+    setLang('es');
+  });
+
   it('stores googleSheetId in localStorage', async () => {
     localStorage.clear();
     localStorage.setItem('googleSheetId', 'initial');
@@ -26,5 +31,15 @@ describe('config-page component', () => {
     input.value = 'new-id';
     input.dispatchEvent(new Event('input'));
     expect(localStorage.getItem('googleSheetId')).toBe('new-id');
+  });
+
+  it('changes and stores language selection', async () => {
+    localStorage.clear();
+    const el = await fixture<any>(html`<config-page></config-page>`);
+    await el.updateComplete;
+    const select = el.shadowRoot!.querySelector('select') as HTMLSelectElement;
+    select.value = 'en';
+    select.dispatchEvent(new Event('change'));
+    expect(localStorage.getItem('lang')).toBe('en');
   });
 });

--- a/src/ui/config-page.ts
+++ b/src/ui/config-page.ts
@@ -2,6 +2,7 @@ import { LitElement, html, css } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { Router } from '@vaadin/router';
 import '@material/web/textfield/outlined-text-field.js';
+import { t, getLang, setLang, LangController, type Lang } from './i18n.js';
 
 @customElement('config-page')
 export class ConfigPage extends LitElement {
@@ -21,9 +22,15 @@ export class ConfigPage extends LitElement {
   @state()
   private googleSheetId = '';
 
+  @state()
+  private language: Lang = getLang();
+
+  private lang = new LangController(this);
+
   connectedCallback() {
     super.connectedCallback();
     this.googleSheetId = localStorage.getItem('googleSheetId') ?? '';
+    this.language = getLang();
   }
 
   private onInput(e: Event) {
@@ -35,15 +42,28 @@ export class ConfigPage extends LitElement {
     Router.go('/');
   }
 
+  private onLangChange(e: Event) {
+    const lang = (e.target as HTMLSelectElement).value as Lang;
+    setLang(lang);
+    this.language = lang;
+  }
+
   render() {
     return html`
-      <h1>Configuración</h1>
+      <h1>${t('config')}</h1>
       <md-outlined-text-field
-        label="Google Sheet ID"
+        .label=${t('sheetId')}
         .value=${this.googleSheetId}
         @input=${this.onInput}
       ></md-outlined-text-field>
-      <button @click=${this.goHome}>Volver</button>
+      <div>
+        <label>${t('language')}:</label>
+        <select @change=${this.onLangChange} .value=${this.language}>
+          <option value="es">Español</option>
+          <option value="en">English</option>
+        </select>
+      </div>
+      <button @click=${this.goHome}>${t('back')}</button>
     `;
   }
 }

--- a/src/ui/i18n.test.ts
+++ b/src/ui/i18n.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// this test dynamically imports the module after manipulating localStorage
+// to ensure the initial language falls back to Spanish when an unsupported
+// value was stored previously
+
+describe('i18n language loading', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    localStorage.clear();
+  });
+
+  it('falls back to Spanish when stored language is invalid', async () => {
+    localStorage.setItem('lang', 'de');
+    const mod = await import('./i18n.js');
+    expect(mod.getLang()).toBe('es');
+    expect(mod.t('menu')).toBe('Menú');
+  });
+});

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -1,0 +1,91 @@
+export type Lang = 'es' | 'en';
+
+const DEFAULT_LANG: Lang = 'es';
+const SUPPORTED_LANGS: Lang[] = ['es', 'en'];
+
+// Load initial language from localStorage or default to Spanish, falling back
+// when the stored value is invalid.
+function loadInitialLang(): Lang {
+  const stored = localStorage.getItem('lang') as Lang | null;
+  if (stored && SUPPORTED_LANGS.includes(stored)) {
+    return stored;
+  }
+  // ensure a consistent value is stored for next loads
+  localStorage.setItem('lang', DEFAULT_LANG);
+  return DEFAULT_LANG;
+}
+
+let currentLang: Lang = loadInitialLang();
+
+// Very small pub-sub to notify components about language changes
+const listeners = new Set<() => void>();
+
+export function getLang(): Lang {
+  return currentLang;
+}
+
+export function setLang(lang: Lang) {
+  currentLang = lang;
+  localStorage.setItem('lang', lang);
+  listeners.forEach((l) => l());
+}
+
+export function subscribe(cb: () => void) {
+  listeners.add(cb);
+  return () => listeners.delete(cb);
+}
+
+// Translation dictionary
+const translations: Record<Lang, Record<string, any>> = {
+  es: {
+    menu: 'Menú',
+    list: 'Lista',
+    config: 'Configuración',
+    back: 'Volver',
+    language: 'Idioma',
+    search: 'Buscar',
+    sheetId: 'ID de Google Sheet',
+    total: (current: number, total: number) =>
+      `Total de productos: ${current} de ${total}`,
+  },
+  en: {
+    menu: 'Menu',
+    list: 'List',
+    config: 'Settings',
+    back: 'Back',
+    language: 'Language',
+    search: 'Search',
+    sheetId: 'Google Sheet ID',
+    total: (current: number, total: number) =>
+      `Total items: ${current} of ${total}`,
+  },
+};
+
+export function t(key: string, ...args: any[]): string {
+  const value = translations[currentLang][key];
+  if (typeof value === 'function') {
+    return value(...args);
+  }
+  return value ?? key;
+}
+
+// Lit controller to update components on language change
+import type { ReactiveController, ReactiveControllerHost } from 'lit';
+
+export class LangController implements ReactiveController {
+  private host: ReactiveControllerHost;
+  private unsub?: () => void;
+
+  constructor(host: ReactiveControllerHost) {
+    this.host = host;
+    host.addController(this);
+  }
+
+  hostConnected() {
+    this.unsub = subscribe(() => this.host.requestUpdate());
+  }
+
+  hostDisconnected() {
+    this.unsub?.();
+  }
+}

--- a/src/ui/shopping-list.test.ts
+++ b/src/ui/shopping-list.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { fixture, html } from '@open-wc/testing';
 import { vi } from 'vitest';
+import { setLang } from './i18n.js';
 
 vi.mock('@material/web/textfield/outlined-text-field.js', () => ({}));
 
@@ -11,6 +12,8 @@ if (!customElements.get('md-outlined-text-field')) {
 }
 
 describe('shopping-list component', () => {
+  beforeEach(() => setLang('es'));
+
   it('renders items', async () => {
     localStorage.clear();
     window.fetch = vi.fn().mockResolvedValue(

--- a/src/ui/shopping-list.ts
+++ b/src/ui/shopping-list.ts
@@ -4,6 +4,7 @@ import '@material/web/textfield/outlined-text-field.js';
 import { repeat } from 'lit/directives/repeat.js';
 import './shopping-item.js';
 import type { ShoppingItem } from '../../core/shopping/models/shopping-item.js';
+import { t, LangController } from './i18n.js';
 
 @customElement('shopping-list')
 export class ShoppingList extends LitElement {
@@ -20,6 +21,8 @@ export class ShoppingList extends LitElement {
 
   @state()
   private filter = '';
+
+  private lang = new LangController(this);
 
   connectedCallback() {
     super.connectedCallback();
@@ -45,11 +48,11 @@ export class ShoppingList extends LitElement {
     );
     return html`
       <md-outlined-text-field
-        label="Search"
+        .label=${t('search')}
         @input=${this.onSearch}
       ></md-outlined-text-field>
       <div class="total">
-        Total de productos: ${filtered.length} de ${this.items.length}
+        ${t('total', filtered.length, this.items.length)}
       </div>
       <div>
         ${repeat(


### PR DESCRIPTION
## Summary
- add simple i18n utility and controller
- allow changing language on settings page and persist selection
- translate UI elements and add tests
- ensure app falls back to Spanish when stored language is invalid

## Testing
- `npm test --silent -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688f5a94731c83219ebefd427bac6173