### PR TITLE
Add Bugsnag error listeners

### DIFF
--- a/src/bugsnag.test.ts
+++ b/src/bugsnag.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Bugsnag from '@bugsnag/js';
+import { initializeBugsnag } from './bugsnag';
+
+vi.mock('@bugsnag/js', () => {
+  return {
+    default: {
+      start: vi.fn(),
+      notify: vi.fn(),
+    },
+  };
+});
+
+describe('initializeBugsnag', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sends window errors to Bugsnag', () => {
+    const cleanup = initializeBugsnag('dummy');
+    const err = new Error('boom');
+    window.dispatchEvent(new ErrorEvent('error', { error: err }));
+    expect((Bugsnag as any).notify).toHaveBeenCalledWith(err);
+    cleanup?.();
+  });
+
+  it('sends unhandled rejections to Bugsnag', () => {
+    const cleanup = initializeBugsnag('dummy');
+    const err = new Error('reject');
+    const event = new Event('unhandledrejection') as PromiseRejectionEvent;
+    (event as any).reason = err;
+    window.dispatchEvent(event);
+    expect((Bugsnag as any).notify).toHaveBeenCalledWith(err);
+    cleanup?.();
+  });
+
+  it('does nothing when apiKey is missing', () => {
+    initializeBugsnag(undefined);
+    expect((Bugsnag as any).start).not.toHaveBeenCalled();
+  });
+});

--- a/src/bugsnag.ts
+++ b/src/bugsnag.ts
@@ -1,0 +1,26 @@
+import Bugsnag from '@bugsnag/js';
+
+export function initializeBugsnag(apiKey?: string) {
+  if (!apiKey) {
+    return;
+  }
+
+  Bugsnag.start({ apiKey });
+
+  const onError = (event: ErrorEvent) => {
+    Bugsnag.notify(event.error ?? new Error(event.message));
+  };
+
+  const onUnhandledRejection = (event: PromiseRejectionEvent) => {
+    const reason = event.reason;
+    Bugsnag.notify(reason instanceof Error ? reason : new Error(String(reason)));
+  };
+
+  window.addEventListener('error', onError);
+  window.addEventListener('unhandledrejection', onUnhandledRejection);
+
+  return () => {
+    window.removeEventListener('error', onError);
+    window.removeEventListener('unhandledrejection', onUnhandledRejection);
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,5 @@
-import Bugsnag from '@bugsnag/js';
+import { initializeBugsnag } from './bugsnag';
 
-const bugsnagKey = import.meta.env.VITE_BUGSNAG_KEY as string | undefined;
-if (bugsnagKey) {
-  Bugsnag.start({ apiKey: bugsnagKey });
-}
+initializeBugsnag(import.meta.env.VITE_BUGSNAG_KEY as string | undefined);
 
 import './ui/app-root.js';


### PR DESCRIPTION
## Summary
- forward global `error` and `unhandledrejection` events to Bugsnag
- cover Bugsnag setup with basic tests

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68907654f5f083219dd0430c83f3fdaa