### PR TITLE
chore: add Playwright E2E testing

### DIFF
--- a/e2e/example.spec.ts
+++ b/e2e/example.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('home page displays BuyBuddies text', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByText('BuyBuddies')).toBeVisible();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,11 @@
       },
       "devDependencies": {
         "@open-wc/testing": "^4.0.0",
+        "@playwright/test": "^1.54.2",
         "@testing-library/dom": "^10.4.1",
         "@types/node": "^24.1.0",
         "happy-dom": "^18.0.1",
+        "playwright": "^1.54.2",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.2",
         "vite": "^7.0.6",
@@ -729,6 +731,22 @@
         "@open-wc/scoped-elements": "^3.0.2",
         "lit": "^2.0.0 || ^3.0.0",
         "lit-html": "^2.0.0 || ^3.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -3970,6 +3988,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "test": "vitest",
     "dev": "vite",
     "prebuild": "npm test",
-    "build": "vite build"
+    "build": "vite build",
+    "postinstall": "playwright install"
   },
   "keywords": [],
   "author": "",
@@ -21,9 +22,11 @@
   },
   "devDependencies": {
     "@open-wc/testing": "^4.0.0",
+    "@playwright/test": "^1.54.2",
     "@testing-library/dom": "^10.4.1",
     "@types/node": "^24.1.0",
     "happy-dom": "^18.0.1",
+    "playwright": "^1.54.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.2",
     "vite": "^7.0.6",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 10000,
+  use: {
+    headless: true,
+    baseURL: 'https://develop.buybuddies.vercel.app',
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'happy-dom',
+    exclude: ['e2e/**'],
   },
 });


### PR DESCRIPTION
## Summary
- setup Playwright config and example spec
- add Playwright dev dependencies and postinstall script
- exclude e2e specs from Vitest

## Testing
- `npm test`
- `npx playwright test` *(fails: net::ERR_TUNNEL_CONNECTION_FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_689053ff836c8321b1a3c9d1aecd9cea