### PR TITLE
fix: normalize Google Sheets item boolean

### DIFF
--- a/infra/google-sheets/shopping-repository.test.ts
+++ b/infra/google-sheets/shopping-repository.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+class FakeRow {
+  constructor(private data: Record<string, unknown>) {}
+  get(key: string) {
+    return this.data[key];
+  }
+}
+
+const loadInfo = vi.fn();
+const getRows = vi.fn();
+
+vi.mock('google-spreadsheet', () => ({
+  GoogleSpreadsheet: vi.fn(),
+}));
+vi.mock('google-auth-library', () => ({
+  GoogleAuth: vi.fn(),
+}));
+
+import { GoogleSpreadsheet } from 'google-spreadsheet';
+import { GoogleSheetsShoppingRepository } from './shopping-repository.js';
+
+const MockedGoogleSpreadsheet = vi.mocked(GoogleSpreadsheet);
+
+describe('GoogleSheetsShoppingRepository', () => {
+  beforeEach(() => {
+    loadInfo.mockClear();
+    getRows.mockReset();
+    MockedGoogleSpreadsheet.mockReset();
+    MockedGoogleSpreadsheet.mockImplementation(() => ({
+      loadInfo,
+      sheetsByIndex: [{ getRows }],
+    }));
+    process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL = 'test@example.com';
+    process.env.GOOGLE_PRIVATE_KEY = 'key';
+  });
+
+  it('loads sheet info and normalizes bought values', async () => {
+    getRows.mockResolvedValue([
+      new FakeRow({
+        id: '1',
+        name: ' A ',
+        quantity: '1',
+        unit: '',
+        group: '',
+        category: '',
+        notes: '',
+        bought: ' X ',
+      }),
+      new FakeRow({
+        id: '2',
+        name: 'B',
+        quantity: '',
+        unit: '',
+        group: '',
+        category: '',
+        notes: '',
+        bought: '',
+      }),
+      new FakeRow({
+        id: '3',
+        name: 'C',
+        quantity: '',
+        unit: '',
+        group: '',
+        category: '',
+        notes: '',
+      }),
+    ]);
+
+    const repo = new GoogleSheetsShoppingRepository('sheetId');
+    const items = await repo.getItems();
+
+    expect(loadInfo).toHaveBeenCalled();
+    expect(items).toStrictEqual([
+      {
+        id: '1',
+        name: 'A',
+        quantity: '1',
+        unit: '',
+        group: '',
+        category: '',
+        notes: '',
+        bought: true,
+      },
+      {
+        id: '2',
+        name: 'B',
+        quantity: '',
+        unit: '',
+        group: '',
+        category: '',
+        notes: '',
+        bought: false,
+      },
+      {
+        id: '3',
+        name: 'C',
+        quantity: '',
+        unit: '',
+        group: '',
+        category: '',
+        notes: '',
+        bought: false,
+      },
+    ]);
+  });
+
+  it('throws when worksheet index 0 is missing', async () => {
+    MockedGoogleSpreadsheet.mockImplementationOnce(() => ({
+      loadInfo,
+      sheetsByIndex: [],
+    }));
+    const repo = new GoogleSheetsShoppingRepository('sheetId');
+    await expect(repo.getItems()).rejects.toThrow('No worksheet found at index 0');
+  });
+});

--- a/infra/google-sheets/shopping-repository.ts
+++ b/infra/google-sheets/shopping-repository.ts
@@ -1,5 +1,5 @@
 import { GoogleSpreadsheet } from 'google-spreadsheet';
-import { JWT } from 'google-auth-library';
+import { GoogleAuth } from 'google-auth-library';
 import type { ShoppingRepository } from '../../core/shopping/ports/shopping-repository.js';
 import type { ShoppingItem } from '../../core/shopping/models/shopping-item.js';
 
@@ -7,24 +7,40 @@ export class GoogleSheetsShoppingRepository implements ShoppingRepository {
   constructor(private sheetId: string) {}
 
   async getItems(): Promise<ShoppingItem[]> {
-    const auth = new JWT({
-      email: process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL as string,
-      key: (process.env.GOOGLE_PRIVATE_KEY as string).replace(/\\n/g, '\n'),
-      scopes: ['https://www.googleapis.com/auth/spreadsheets'],
+    const auth = new GoogleAuth({
+      credentials: {
+        client_email: process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL!,
+        private_key: process.env.GOOGLE_PRIVATE_KEY!.replace(/\\n/g, '\n'),
+      },
+      scopes: ['https://www.googleapis.com/auth/spreadsheets.readonly'],
     });
+
     const doc = new GoogleSpreadsheet(this.sheetId, auth);
     await doc.loadInfo();
-    const sheet = doc.sheetsByIndex[0]!;
+
+    const sheet = doc.sheetsByIndex?.[0];
+    if (!sheet) {
+      throw new Error('No worksheet found at index 0');
+    }
+
     const rows = await sheet.getRows();
-    return rows.map((r: any) => ({
-      id: r.id,
-      name: r.name,
-      quantity: r.quantity,
-      unit: r.unit,
-      group: r.group,
-      category: r.category,
-      notes: r.notes,
-      bought: r.bought === 'TRUE' || r.bought === true,
+
+    const toBool = (v: unknown): boolean => {
+      if (typeof v === 'boolean') return v;
+      const s = String(v ?? '').trim().toLowerCase();
+      if (!s) return false; // por defecto false
+      return s === 'true' || s === '1' || s === 'yes' || s === 'y' || s === 'x';
+    };
+
+    return rows.map((row) => ({
+      id: String(row.get('id') ?? '').trim(),
+      name: String(row.get('name') ?? '').trim(),
+      quantity: String(row.get('quantity') ?? '').trim(),
+      unit: String(row.get('unit') ?? '').trim(),
+      group: String(row.get('group') ?? '').trim(),
+      category: String(row.get('category') ?? '').trim(),
+      notes: String(row.get('notes') ?? '').trim(),
+      bought: toBool(row.get('bought')), // booleano garantizado, false por defecto
     }));
   }
 }


### PR DESCRIPTION
## Summary
- ensure Google Sheets repository loads sheet metadata and selects first worksheet safely
- normalize `bought` values to boolean with default `false`
- add unit tests covering metadata loading and boolean normalization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689755d7524c83218dc5f47794548d74