### PR TITLE
Add robust Google Sheets API error handling

### DIFF
--- a/api/shopping/get.test.ts
+++ b/api/shopping/get.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../infra/google-sheets/shopping-repository.js', () => ({
+  GoogleSheetsShoppingRepository: vi.fn(),
+}));
+vi.mock('../../infra/mock/shopping-repository.js', () => ({
+  MockShoppingRepository: vi.fn(),
+}));
+
+import handler from './get.js';
+import { GoogleSheetsShoppingRepository } from '../../infra/google-sheets/shopping-repository.js';
+import { MockShoppingRepository } from '../../infra/mock/shopping-repository.js';
+
+const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+describe('api/shopping/get', () => {
+  const createRes = () => {
+    const json = vi.fn();
+    return { status: vi.fn(() => ({ json })) } as any;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleError.mockClear();
+  });
+
+  it('returns shopping items on success', async () => {
+    vi.mocked(MockShoppingRepository).mockImplementation(() => ({
+      getItems: vi.fn().mockResolvedValue(['a']),
+    }));
+    const res = createRes();
+    await handler({}, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.status.mock.results[0].value.json).toHaveBeenCalledWith({
+      success: true,
+      data: ['a'],
+    });
+  });
+
+  it('returns an error object on failure', async () => {
+    vi.mocked(GoogleSheetsShoppingRepository).mockImplementation(
+      () => ({
+        getItems: vi.fn().mockRejectedValue({ code: 401 }),
+      } as any),
+    );
+    const res = createRes();
+    await handler({ query: { googleSheetId: 'id' } }, res);
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.status.mock.results[0].value.json).toHaveBeenCalledWith({
+      success: false,
+      error: 'No autorizado: revisa las credenciales',
+    });
+  });
+});

--- a/api/shopping/get.ts
+++ b/api/shopping/get.ts
@@ -15,6 +15,18 @@ export default async function handler(req: Request, res: Response) {
   const repo = googleSheetId
     ? new GoogleSheetsShoppingRepository(googleSheetId)
     : new MockShoppingRepository();
-  const items = await getShoppingList(repo);
-  res.status(200).json(items);
+  try {
+    const items = await getShoppingList(repo);
+    res.status(200).json({ success: true, data: items });
+  } catch (error: any) {
+    console.error('Error fetching shopping list:', error);
+    let message = 'Error al obtener la lista de compras';
+    if (error?.code === 401) message = 'No autorizado: revisa las credenciales';
+    else if (error?.code === 404) message = 'Hoja no encontrada';
+    else if (error?.code === 'NETWORK')
+      message = 'Error de red al conectar con Google Sheets';
+    else if (error?.code === 'FORMAT')
+      message = 'Error en el formato de los datos de la hoja de cálculo';
+    res.status(500).json({ success: false, error: message });
+  }
 }

--- a/infra/google-sheets/shopping-repository.ts
+++ b/infra/google-sheets/shopping-repository.ts
@@ -1,4 +1,4 @@
-import { GoogleSpreadsheet } from 'google-spreadsheet';
+import { GoogleSpreadsheet, GoogleSpreadsheetWorksheet } from 'google-spreadsheet';
 import { GoogleAuth } from 'google-auth-library';
 import type { ShoppingRepository } from '../../core/shopping/ports/shopping-repository.js';
 import type { ShoppingItem } from '../../core/shopping/models/shopping-item.js';
@@ -6,86 +6,138 @@ import type { ShoppingItem } from '../../core/shopping/models/shopping-item.js';
 const toSheetBool = (val: boolean | undefined) => (val ? 'TRUE' : 'FALSE');
 const toSheetString = (val: string | undefined) => val ?? '';
 
+const mapGoogleError = (error: any, defaultMessage: string): never => {
+  console.error(defaultMessage + ':', error);
+  let message = defaultMessage;
+  let code = error?.code;
+  if (error?.code === 401 || error?.code === 403) {
+    message = 'No autorizado: revisa las credenciales';
+    code = 401;
+  } else if (error?.code === 404) {
+    message = 'Hoja no encontrada';
+    code = 404;
+  } else if (
+    error?.code === 'NETWORK' ||
+    error?.code === 'ENOTFOUND' ||
+    error?.code === 'ECONNREFUSED' ||
+    error?.code === 'ECONNRESET'
+  ) {
+    message = 'Error de red al conectar con Google Sheets';
+    code = 'NETWORK';
+  } else if (error?.code === 'FORMAT') {
+    message = 'Error en el formato de los datos de la hoja de cálculo';
+    code = 'FORMAT';
+  }
+  const err: any = new Error(message);
+  err.code = code;
+  throw err;
+};
+
 export class GoogleSheetsShoppingRepository implements ShoppingRepository {
   constructor(private sheetId: string) {}
 
-  private async getSheet(readonly: boolean) {
-    const auth = new GoogleAuth({
-      credentials: {
-        client_email: process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL!,
-        private_key: process.env.GOOGLE_PRIVATE_KEY!.replace(/\\n/g, '\n'),
-      },
-      scopes: [
-        readonly
-          ? 'https://www.googleapis.com/auth/spreadsheets.readonly'
-          : 'https://www.googleapis.com/auth/spreadsheets',
-      ],
-    });
+  private async getSheet(readonly: boolean): Promise<GoogleSpreadsheetWorksheet> {
+    try {
+      const auth = new GoogleAuth({
+        credentials: {
+          client_email: process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL!,
+          private_key: process.env.GOOGLE_PRIVATE_KEY!.replace(/\\n/g, '\n'),
+        },
+        scopes: [
+          readonly
+            ? 'https://www.googleapis.com/auth/spreadsheets.readonly'
+            : 'https://www.googleapis.com/auth/spreadsheets',
+        ],
+      });
 
-    const doc = new GoogleSpreadsheet(this.sheetId, auth);
-    await doc.loadInfo();
+      const doc = new GoogleSpreadsheet(this.sheetId, auth);
+      await doc.loadInfo();
 
-    const sheet = doc.sheetsByIndex?.[0];
-    if (!sheet) {
-      throw new Error('No worksheet found at index 0');
+      const sheet = doc.sheetsByIndex?.[0];
+      if (!sheet) {
+        const err: any = new Error('Hoja no encontrada');
+        err.code = 404;
+        throw err;
+      }
+
+      return sheet;
+    } catch (error) {
+      return mapGoogleError(error, 'Error al acceder a Google Sheets');
     }
-
-    return sheet;
   }
 
   async getItems(): Promise<ShoppingItem[]> {
-    const sheet = await this.getSheet(true);
-    const rows = await sheet.getRows();
+    try {
+      const sheet = await this.getSheet(true);
+      const rows = await sheet.getRows();
+      if (!Array.isArray(rows)) {
+        const err: any = new Error('Invalid data');
+        err.code = 'FORMAT';
+        throw err;
+      }
 
-    const toBool = (v: unknown): boolean => {
-      if (typeof v === 'boolean') return v;
-      const s = String(v ?? '').trim().toLowerCase();
-      if (!s) return false; // por defecto false
-      return s === 'true' || s === '1' || s === 'yes' || s === 'y' || s === 'x';
-    };
+      const toBool = (v: unknown): boolean => {
+        if (typeof v === 'boolean') return v;
+        const s = String(v ?? '').trim().toLowerCase();
+        if (!s) return false; // por defecto false
+        return s === 'true' || s === '1' || s === 'yes' || s === 'y' || s === 'x';
+      };
 
-    return rows.map((row) => ({
-      id: String(row.get('id') ?? '').trim(),
-      name: String(row.get('name') ?? '').trim(),
-      quantity: String(row.get('quantity') ?? '').trim(),
-      unit: String(row.get('unit') ?? '').trim(),
-      group: String(row.get('group') ?? '').trim(),
-      category: String(row.get('category') ?? '').trim(),
-      notes: String(row.get('notes') ?? '').trim(),
-      bought: toBool(row.get('bought')), // booleano garantizado, false por defecto
-    }));
+      return rows.map((row) => ({
+        id: String(row.get('id') ?? '').trim(),
+        name: String(row.get('name') ?? '').trim(),
+        quantity: String(row.get('quantity') ?? '').trim(),
+        unit: String(row.get('unit') ?? '').trim(),
+        group: String(row.get('group') ?? '').trim(),
+        category: String(row.get('category') ?? '').trim(),
+        notes: String(row.get('notes') ?? '').trim(),
+        bought: toBool(row.get('bought')), // booleano garantizado, false por defecto
+      }));
+    } catch (error) {
+      return mapGoogleError(error, 'Error al obtener la lista de compras');
+    }
   }
 
   async addItem(item: ShoppingItem): Promise<void> {
-    const sheet = await this.getSheet(false);
-    await sheet.addRow({
-      id: item.id,
-      name: item.name,
-      quantity: item.quantity,
-      unit: item.unit,
-      group: item.group,
-      category: item.category,
-      notes: toSheetString(item.notes),
-      bought: toSheetBool(item.bought),
-    });
+    try {
+      const sheet = await this.getSheet(false);
+      await sheet.addRow({
+        id: item.id,
+        name: item.name,
+        quantity: item.quantity,
+        unit: item.unit,
+        group: item.group,
+        category: item.category,
+        notes: toSheetString(item.notes),
+        bought: toSheetBool(item.bought),
+      });
+    } catch (error) {
+      mapGoogleError(error, 'Error al agregar el artículo');
+    }
   }
 
   async updateItem(item: ShoppingItem): Promise<void> {
-    const sheet = await this.getSheet(false);
-    const rows = await sheet.getRows();
-    const row = rows.find(
-      (r) => String(r.get('id') ?? '').trim() === item.id,
-    );
-    if (!row) {
-      throw new Error(`Item with id ${item.id} not found`);
+    try {
+      const sheet = await this.getSheet(false);
+      const rows = await sheet.getRows();
+      const row = rows.find(
+        (r) => String(r.get('id') ?? '').trim() === item.id,
+      );
+      if (!row) {
+        const err: any = new Error(`Item with id ${item.id} not found`);
+        err.code = 404;
+        throw err;
+      }
+      row.set('name', item.name);
+      row.set('quantity', item.quantity);
+      row.set('unit', item.unit);
+      row.set('group', item.group);
+      row.set('category', item.category);
+      row.set('notes', toSheetString(item.notes));
+      row.set('bought', toSheetBool(item.bought));
+      await row.save();
+    } catch (error) {
+      mapGoogleError(error, 'Error al actualizar el artículo');
     }
-    row.set('name', item.name);
-    row.set('quantity', item.quantity);
-    row.set('unit', item.unit);
-    row.set('group', item.group);
-    row.set('category', item.category);
-    row.set('notes', toSheetString(item.notes));
-    row.set('bought', toSheetBool(item.bought));
-    await row.save();
   }
 }

--- a/src/ui/shopping-list.ts
+++ b/src/ui/shopping-list.ts
@@ -41,7 +41,9 @@ export class ShoppingList extends LitElement {
       ? `/api/shopping/get?googleSheetId=${encodeURIComponent(sheetId)}`
       : '/api/shopping/get';
     const res = await fetch(url);
-    this.items = await res.json();
+    const jsonData = await res.json();
+
+    this.items = jsonData.data;
   }
 
   render() {

--- a/src/ui/shopping-list.ts
+++ b/src/ui/shopping-list.ts
@@ -47,9 +47,9 @@ export class ShoppingList extends LitElement {
   }
 
   render() {
-    const filtered = filterShoppingItems(this.items, this.filters);
-    const groups = [...new Set(this.items.map((i) => i.group))];
-    const categories = [...new Set(this.items.map((i) => i.category))];
+    const filtered = filterShoppingItems(this.items || [], this.filters);
+    const groups = [...new Set((this.items || []).map((i) => i.group))];
+    const categories = [...new Set((this.items || []).map((i) => i.category))];
     return html`
       <shopping-filters
         .groups=${groups}
@@ -59,7 +59,7 @@ export class ShoppingList extends LitElement {
           (this.filters = e.detail)}
       ></shopping-filters>
       <div class="total">
-        Total de productos: ${filtered.length} de ${this.items.length}
+        Total de productos: ${filtered.length} de ${(this.items || []).length}
       </div>
       <div>
         ${repeat(


### PR DESCRIPTION
## Summary
- type `getSheet` to always return a worksheet and map errors via `mapGoogleError`
- stub `console.error` in tests to avoid noisy logs
- cast mocked GoogleSheets repository to satisfy TypeScript

## Testing
- `npx vitest run`
- `npx tsc -p tsconfig.json --noEmit`
- `CI=true npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689785c3a3c8832191514b2ecafa359d