### PR TITLE
chore: configure ESLint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,13 +1,37 @@
+/** @type {import('eslint').Linter.Config} */
 module.exports = {
-  env: {
-    es2020: true,
-    node: true,
-    browser: true,
+  root: true,
+  env: { es2022: true, node: true, browser: true },
+  parser: '@typescript-eslint/parser',
+  parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+  plugins: [
+    '@typescript-eslint',
+    'import',
+    'promise',
+    'unicorn',
+    'lit',
+    'lit-a11y',
+    'simple-import-sort'
+  ],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:import/recommended',
+    'plugin:promise/recommended',
+    'plugin:unicorn/recommended',
+    'plugin:lit/recommended',
+    'plugin:lit-a11y/recommended',
+    'prettier'
+  ],
+  settings: { 'import/resolver': { node: { extensions: ['.ts', '.js'] } } },
+  rules: {
+    'unicorn/prefer-module': 'off',
+    'unicorn/filename-case': 'off',
+    'import/no-unresolved': 'off',
+    'import/order': 'off',
+    'simple-import-sort/imports': 'warn',
+    'simple-import-sort/exports': 'warn',
+    '@typescript-eslint/explicit-function-return-type': 'off'
   },
-  extends: ['eslint:recommended'],
-  parserOptions: {
-    ecmaVersion: 'latest',
-    sourceType: 'module',
-  },
-  rules: {},
+  ignorePatterns: ['dist', 'node_modules']
 };


### PR DESCRIPTION
## Summary
- add comprehensive ESLint config with TypeScript, import, promise, unicorn, lit, a11y, and simple-import-sort rules
- ignore build and dependency directories in ESLint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897c4b014808321917e8db4b2c0a666