### PR TITLE
chore: enable strict TypeScript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,18 +6,22 @@
     "rootDir": ".",
     "outDir": "dist",
 
-    "strict": false,
-    "noUncheckedIndexedAccess": false,
-    "exactOptionalPropertyTypes": false,
-
+    "strict": true,
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true,
+
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
+
     "experimentalDecorators": true,
-    "useDefineForClassFields": false
+    "useDefineForClassFields": false,
+    "types": ["vite/client", "node"]
   },
   "include": [
     "api/**/*.ts",


### PR DESCRIPTION
## Summary
- enable strict TypeScript config with Lit compatibility
- keep typecheck prebuild step for Vercel
- run tests during prebuild

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_6897de0df51c8321bac15ca179e41a47