### PR TITLE
chore: add lint and format checks

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 dist
 node_modules
+coverage

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -3,7 +3,10 @@ module.exports = {
   root: true,
   env: { es2022: true, node: true, browser: true },
   parser: '@typescript-eslint/parser',
-  parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
   plugins: [
     '@typescript-eslint',
     'import',
@@ -21,17 +24,26 @@ module.exports = {
     'plugin:unicorn/recommended',
     'plugin:lit/recommended',
     'plugin:lit-a11y/recommended',
-    'prettier'
+    // ¡siempre al final!
+    'eslint-config-prettier'
   ],
-  settings: { 'import/resolver': { node: { extensions: ['.ts', '.js'] } } },
+  settings: {
+    'import/resolver': { node: { extensions: ['.ts', '.js'] } }
+  },
   rules: {
-    'unicorn/prefer-module': 'off',
-    'unicorn/filename-case': 'off',
-    'import/no-unresolved': 'off',
-    'import/order': 'off',
+    // Proyecto
     'simple-import-sort/imports': 'warn',
     'simple-import-sort/exports': 'warn',
+
+    // Unicorn
+    'unicorn/prefer-module': 'off',
+    'unicorn/filename-case': 'off',
+
+    // Import
+    'import/no-unresolved': 'off',
+
+    // TS
     '@typescript-eslint/explicit-function-return-type': 'off'
   },
-  ignorePatterns: ['dist', 'node_modules']
+  ignorePatterns: ['dist', 'node_modules', 'coverage']
 };

--- a/package.json
+++ b/package.json
@@ -5,9 +5,13 @@
   "scripts": {
     "test": "vitest",
     "dev": "vite",
-    "prebuild": "npm run typecheck && npm test",
+    "prebuild": "npm run lint && npm run format:check && npm run typecheck && npm test",
     "build": "vite build",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint . --ext .ts,.js",
+    "lint:fix": "npm run lint -- --fix",
+    "format": "prettier . --write",
+    "format:check": "prettier . --check"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- configure ESLint for TypeScript, Lit and Prettier
- ignore build artifacts and coverage files in ESLint
- ensure prebuild runs lint, format:check, typecheck and tests

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_6897e6510c2883218ff5dde2102bc134