### PR TITLE
chore: add Vercel config for Node 22 and npm ci

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "installCommand": "npm ci",
+  "engines": {
+    "node": "22.x"
+  }
+}


### PR DESCRIPTION
## Summary
- configure Vercel to install dependencies with `npm ci`
- require Node.js 22.x on Vercel

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68987a4243e48321b3bf4cb1d4c2f3ee