### PR TITLE
Allow up to 50 ESLint warnings in lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prebuild": "npm run print:node && npm run lint && npm run format:check && npm run typecheck && npm test",
     "build": "vite build",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint . --ext .ts,.js",
+    "lint": "eslint . --ext .ts,.js --max-warnings=50",
     "lint:fix": "npm run lint -- --fix",
     "format": "prettier . --write",
     "format:check": "prettier . --check",


### PR DESCRIPTION
## Summary
- permit up to 50 warnings before eslint fails

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898f7733c748321980818fd213a538d