### PR TITLE
feat: add Playwright smoke test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules
 .env
 dist
+
+playwright-report/
+test-results/

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,35 +7,40 @@
     "": {
       "name": "buy-buddies",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@bugsnag/js": "^7.25.0",
-        "@material/web": "^2.3.0",
-        "@vaadin/router": "^2.0.0",
-        "google-auth-library": "^10.2.0",
-        "google-spreadsheet": "^4.1.5",
-        "lit": "^3.3.1"
+        "@bugsnag/js": "7.25.0",
+        "@material/web": "2.3.0",
+        "@vaadin/router": "2.0.0",
+        "google-auth-library": "10.2.0",
+        "google-spreadsheet": "4.1.5",
+        "lit": "3.3.1"
       },
       "devDependencies": {
-        "@open-wc/testing": "^4.0.0",
-        "@testing-library/dom": "^10.4.1",
-        "@types/node": "^24.1.0",
-        "@typescript-eslint/eslint-plugin": "^8.39.0",
-        "@typescript-eslint/parser": "^8.39.0",
-        "eslint": "^9.33.0",
-        "eslint-config-prettier": "^10.1.8",
-        "eslint-plugin-import": "^2.32.0",
-        "eslint-plugin-lit": "^2.1.1",
-        "eslint-plugin-lit-a11y": "^5.1.1",
-        "eslint-plugin-promise": "^7.2.1",
-        "eslint-plugin-simple-import-sort": "^12.1.1",
-        "eslint-plugin-unicorn": "^60.0.0",
-        "happy-dom": "^18.0.1",
-        "prettier": "^3.6.2",
-        "ts-node": "^10.9.2",
-        "typescript": "^5.9.2",
-        "vite": "^7.0.6",
-        "vitest": "^3.2.4"
+        "@open-wc/testing": "4.0.0",
+        "@playwright/test": "1.54.2",
+        "@testing-library/dom": "10.4.1",
+        "@types/node": "24.1.0",
+        "@typescript-eslint/eslint-plugin": "8.39.0",
+        "@typescript-eslint/parser": "8.39.0",
+        "eslint": "9.33.0",
+        "eslint-config-prettier": "10.1.8",
+        "eslint-plugin-import": "2.32.0",
+        "eslint-plugin-lit": "2.1.1",
+        "eslint-plugin-lit-a11y": "5.1.1",
+        "eslint-plugin-promise": "7.2.1",
+        "eslint-plugin-simple-import-sort": "12.1.1",
+        "eslint-plugin-unicorn": "60.0.0",
+        "happy-dom": "18.0.1",
+        "prettier": "3.6.2",
+        "ts-node": "10.9.2",
+        "typescript": "5.9.2",
+        "vite": "7.0.6",
+        "vitest": "3.2.4"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1041,6 +1046,22 @@
         "@open-wc/scoped-elements": "^3.0.2",
         "lit": "^2.0.0 || ^3.0.0",
         "lit-html": "^2.0.0 || ^3.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -6786,6 +6807,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pluralize": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "format:check": "prettier . --check",
     "print:node": "node -v",
     "preinstall": "node scripts/check-node-version.js",
-    "clean": "rm -rf node_modules dist .vite coverage && npm install"
+    "clean": "rm -rf node_modules dist .vite coverage && npm install",
+    "e2e": "playwright test",
+    "e2e:smoke": "playwright test tests/e2e/smoke.spec.ts"
   },
   "keywords": [],
   "author": "",
@@ -34,6 +36,7 @@
   },
   "devDependencies": {
     "@open-wc/testing": "4.0.0",
+    "@playwright/test": "1.54.2",
     "@testing-library/dom": "10.4.1",
     "@types/node": "24.1.0",
     "@typescript-eslint/eslint-plugin": "8.39.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  timeout: 30_000,
+  retries: 1,
+  reporter: [['list']],
+  use: {
+    baseURL: process.env.BASE_URL, // se la pasaremos en CI
+    headless: true,
+  },
+  // Si quieres limitar a Chromium más adelante, añadiremos "projects"
+});

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('la home carga y tiene un título', async ({ page }) => {
+  await page.goto('/'); // usa baseURL desde la config
+  const title = await page.title();
+  expect(title.trim().length).toBeGreaterThan(0);
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,11 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'happy-dom',
+    exclude: [
+      'tests/e2e/**',
+      'node_modules/**',
+      'dist/**',
+    ],
+    include: ['**/*.test.ts'],
   },
 });


### PR DESCRIPTION
## Summary
- set up Playwright with config and smoke test
- add Playwright e2e npm scripts
- ignore Playwright artifacts
- prevent Vitest from running Playwright e2e tests

## Testing
- `npm install --engine-strict=false` (fails: Node 22+ required)
- `npm test` (fails: vitest not found because dependencies weren't installed)


------
https://chatgpt.com/codex/tasks/task_e_689900a180c883219a24d6f4b67657e4