### PR TITLE
Run Playwright smoke test after Vercel deployments

### DIFF
--- a/.github/workflows/e2e-on-vercel-deploy.yml
+++ b/.github/workflows/e2e-on-vercel-deploy.yml
@@ -1,0 +1,39 @@
+name: E2E on Vercel Deploy
+
+on:
+  deployment_status:
+
+permissions:
+  contents: read
+  deployments: read
+
+jobs:
+  e2e:
+    if: ${{ github.event.deployment_status.state == 'success' && github.event.deployment_status.target_url != '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      BASE_URL: ${{ github.event.deployment_status.target_url }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install project deps (lockfile)
+        run: npm ci
+
+      # Si @playwright/test ya es devDependency, esto solo instala navegadores
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Show deployed URL
+        run: echo "Testing URL: $BASE_URL"
+
+      - name: Run E2E smoke
+        run: npx playwright test --config=playwright.config.ts

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,7 +1,6 @@
-import { expect, test } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 
-test('la home carga y tiene un título', async ({ page }) => {
-  await page.goto('/'); // usa baseURL desde la config
-  const title = await page.title();
-  expect(title.trim().length).toBeGreaterThan(0);
+test('la home carga y muestra el título correcto', async ({ page }) => {
+  await page.goto('/'); // usa BASE_URL desde la config
+  await expect(page).toHaveTitle('Buy Buddies');
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'happy-dom',
-    exclude: ['tests/e2e/**', 'node_modules/**', 'dist/**'],
     include: ['**/*.test.ts'],
+    exclude: ['tests/e2e/**', 'node_modules/**', 'dist/**'],
   },
 });


### PR DESCRIPTION
## Summary
- run Playwright smoke test on Vercel deployment status events
- assert home page title is "Buy Buddies"
- exclude e2e specs from Vitest

## Testing
- `npm ci`
- `npm run lint` *(fails: warning about import order)*

------
https://chatgpt.com/codex/tasks/task_e_689a25fe55b883219e831f4c7662212d