### PR TITLE
fix: address formatting and workflow issues

### DIFF
--- a/.github/workflows/e2e-on-vercel-deploy.yml
+++ b/.github/workflows/e2e-on-vercel-deploy.yml
@@ -33,7 +33,8 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: Show deployed URL
-        run: echo "Testing URL: $BASE_URL"
+        run: |
+          echo "Testing URL: $BASE_URL"
 
       - name: Run E2E smoke
         run: npx playwright test --config=playwright.config.ts

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint . --ext .ts,.js --max-warnings=50",
     "lint:fix": "npm run lint -- --fix",
     "format": "prettier . --write",
-    "format:check": "prettier . --check --loglevel warn || echo '⚠️ Formato incorrecto, revisa con: npm run format'",
+    "format:check": "prettier . --check --log-level warn || echo '⚠️ Formato incorrecto, revisa con: npm run format'",
     "print:node": "node -v",
     "preinstall": "node scripts/check-node-version.js",
     "clean": "rm -rf node_modules dist .vite coverage && npm install",

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test('la home carga y muestra el título correcto', async ({ page }) => {
   await page.goto('/'); // usa BASE_URL desde la config


### PR DESCRIPTION
## Summary
- resolve prettier error in E2E workflow by using block `run` syntax
- use correct `--log-level` flag for prettier check script
- tidy Playwright smoke test import order

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a293781108321a4e8435f16b0ac62