### PR TITLE
Translate Google Sheets repository logs to English

### DIFF
--- a/infra/google-sheets/shopping-repository.test.ts
+++ b/infra/google-sheets/shopping-repository.test.ts
@@ -118,25 +118,25 @@ describe('GoogleSheetsShoppingRepository', () => {
   it('throws when worksheet index 0 is missing', async () => {
     MockedGoogleSpreadsheet.mockImplementationOnce(() => ({ loadInfo, sheetsByIndex: [] }) as any);
     const repo = new GoogleSheetsShoppingRepository('sheetId');
-    await expect(repo.getItems()).rejects.toThrow('Hoja no encontrada');
+    await expect(repo.getItems()).rejects.toThrow('Sheet not found');
   });
 
   it('maps auth errors to user friendly messages', async () => {
     loadInfo.mockRejectedValueOnce({ code: 401 });
     const repo = new GoogleSheetsShoppingRepository('sheetId');
-    await expect(repo.getItems()).rejects.toThrow('No autorizado: revisa las credenciales');
+    await expect(repo.getItems()).rejects.toThrow('Unauthorized: check credentials');
   });
 
   it('maps network errors to user friendly messages', async () => {
     loadInfo.mockRejectedValueOnce({ code: 'ENOTFOUND' });
     const repo = new GoogleSheetsShoppingRepository('sheetId');
-    await expect(repo.getItems()).rejects.toThrow('Error de red al conectar con Google Sheets');
+    await expect(repo.getItems()).rejects.toThrow('Network error connecting to Google Sheets');
   });
 
   it('throws format error when rows are not an array', async () => {
     getRows.mockResolvedValueOnce(null as any);
     const repo = new GoogleSheetsShoppingRepository('sheetId');
-    await expect(repo.getItems()).rejects.toThrow('Error en el formato de los datos de la hoja de cálculo');
+    await expect(repo.getItems()).rejects.toThrow('Spreadsheet data format error');
   });
 
   it('writes bought as TRUE or FALSE when adding items', async () => {

--- a/infra/google-sheets/shopping-repository.ts
+++ b/infra/google-sheets/shopping-repository.ts
@@ -12,10 +12,10 @@ const mapGoogleError = (error: any, defaultMessage: string): never => {
   let message = defaultMessage;
   let code = error?.code;
   if (error?.code === 401 || error?.code === 403) {
-    message = 'No autorizado: revisa las credenciales';
+    message = 'Unauthorized: check credentials';
     code = 401;
   } else if (error?.code === 404) {
-    message = 'Hoja no encontrada';
+    message = 'Sheet not found';
     code = 404;
   } else if (
     error?.code === 'NETWORK' ||
@@ -23,10 +23,10 @@ const mapGoogleError = (error: any, defaultMessage: string): never => {
     error?.code === 'ECONNREFUSED' ||
     error?.code === 'ECONNRESET'
   ) {
-    message = 'Error de red al conectar con Google Sheets';
+    message = 'Network error connecting to Google Sheets';
     code = 'NETWORK';
   } else if (error?.code === 'FORMAT') {
-    message = 'Error en el formato de los datos de la hoja de cálculo';
+    message = 'Spreadsheet data format error';
     code = 'FORMAT';
   }
   const err: any = new Error(message);
@@ -56,14 +56,14 @@ export class GoogleSheetsShoppingRepository implements ShoppingRepository {
 
       const sheet = doc.sheetsByIndex?.[0];
       if (!sheet) {
-        const err: any = new Error('Hoja no encontrada');
+        const err: any = new Error('Sheet not found');
         err.code = 404;
         throw err;
       }
 
       return sheet;
     } catch (error) {
-      return mapGoogleError(error, 'Error al acceder a Google Sheets');
+      return mapGoogleError(error, 'Error accessing Google Sheets');
     }
   }
 
@@ -97,7 +97,7 @@ export class GoogleSheetsShoppingRepository implements ShoppingRepository {
         bought: toBool(row.get('bought')), // booleano garantizado, false por defecto
       }));
     } catch (error) {
-      return mapGoogleError(error, 'Error al obtener la lista de compras');
+      return mapGoogleError(error, 'Error fetching shopping list');
     }
   }
 
@@ -115,7 +115,7 @@ export class GoogleSheetsShoppingRepository implements ShoppingRepository {
         bought: toSheetBool(item.bought),
       });
     } catch (error) {
-      mapGoogleError(error, 'Error al agregar el artículo');
+      mapGoogleError(error, 'Error adding the item');
     }
   }
 
@@ -138,7 +138,7 @@ export class GoogleSheetsShoppingRepository implements ShoppingRepository {
       row.set('bought', toSheetBool(item.bought));
       await row.save();
     } catch (error) {
-      mapGoogleError(error, 'Error al actualizar el artículo');
+      mapGoogleError(error, 'Error updating the item');
     }
   }
 }


### PR DESCRIPTION
## Summary
- Translate Google Sheets repository error logs from Spanish to English for clearer diagnostics.
- Adjust repository tests to expect English log messages.

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689a23faf8608321953ac158edbe7666