### PR TITLE
Cache Playwright browsers and limit e2e to Chromium

### DIFF
--- a/.github/workflows/e2e-on-vercel-deploy.yml
+++ b/.github/workflows/e2e-on-vercel-deploy.yml
@@ -7,6 +7,10 @@ permissions:
   contents: read
   deployments: read
 
+concurrency:
+  group: e2e-${{ github.event.deployment_status.environment_url || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   e2e:
     if: ${{ github.event.deployment_status.state == 'success' && github.event.deployment_status.target_url != '' }}
@@ -25,12 +29,21 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
+      # Cache de navegadores de Playwright (Linux usa esta ruta)
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
       - name: Install project deps (lockfile)
         run: npm ci
 
       # Si @playwright/test ya es devDependency, esto solo instala navegadores
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps
+      - name: Install Playwright browsers (chromium only)
+        run: npx playwright install --with-deps chromium
 
       - name: Show deployed URL
         run: |
@@ -38,3 +51,10 @@ jobs:
 
       - name: Run E2E smoke
         run: npx playwright test --config=playwright.config.ts
+
+      - name: Upload Playwright report (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from '@playwright/test';
+import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   timeout: 30_000,
@@ -8,5 +8,7 @@ export default defineConfig({
     baseURL: process.env.BASE_URL, // se la pasaremos en CI
     headless: true,
   },
-  // Si quieres limitar a Chromium más adelante, añadiremos "projects"
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
 });


### PR DESCRIPTION
## Summary
- cache Playwright browser binaries and install only Chromium in e2e workflow
- cancel overlapping e2e jobs and upload report on failure
- restrict Playwright configuration to a single Chromium project

## Testing
- `npx vitest run`
- `npx playwright install chromium` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_689a2e2caee88321b09e4cd6b60e5a3f