### PR TITLE
chore: split test scripts for unit and e2e runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
   },
   "engineStrict": true,
   "scripts": {
-    "test": "vitest",
+    "test:unit": "vitest",
+    "test:e2e": "playwright test",
+    "test": "npm run test:unit",
     "dev": "vite",
-    "prebuild": "npm run print:node && npm run lint && npm run format:check && npm run typecheck && npm test",
+    "prebuild": "npm run print:node && npm run lint && npm run format:check && npm run typecheck && npm run test:unit",
     "build": "vite build",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --ext .ts,.js --max-warnings=50",


### PR DESCRIPTION
## Summary
- add dedicated test:unit and test:e2e scripts
- update test and prebuild scripts to use test:unit

## Testing
- `npm run test:unit`
- `npm run test:e2e` *(fails: Cannot redefine property: Symbol($$jest-matchers-object))*

------
https://chatgpt.com/codex/tasks/task_e_689a396a679483218becaf4edd0b2f7f