### PR TITLE
chore: isolate e2e and unit tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
+  testDir: 'tests/e2e',
+  testMatch: ['**/*.spec.ts'],
   timeout: 30_000,
   retries: 1,
   reporter: [['list']],


### PR DESCRIPTION
## Summary
- scope Playwright to `tests/e2e/**/*.spec.ts` so it skips unit tests
- confirm Vitest only collects `*.test.ts`

## Testing
- `npm test`
- `BASE_URL=http://localhost npm run test:e2e` *(fails: missing Playwright dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689a3df0fe788321914c05245fd39b4d