### PR TITLE
feat: allow bypassing vercel protection in e2e

### DIFF
--- a/.github/workflows/e2e-on-vercel-deploy.yml
+++ b/.github/workflows/e2e-on-vercel-deploy.yml
@@ -18,6 +18,7 @@ jobs:
     timeout-minutes: 15
     env:
       BASE_URL: ${{ github.event.deployment_status.target_url }}
+      VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
     steps:
       - name: Checkout

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const bypass = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+const extraHeaders = bypass ? { 'x-vercel-protection-bypass': bypass } : undefined;
+
 export default defineConfig({
   testDir: 'tests/e2e',
   testMatch: ['**/*.spec.ts'],
@@ -9,6 +12,7 @@ export default defineConfig({
   use: {
     baseURL: process.env.BASE_URL, // se la pasaremos en CI
     headless: true,
+    extraHTTPHeaders: extraHeaders,
   },
   projects: [
     { name: 'chromium', use: { ...devices['Desktop Chrome'] } },

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,6 +1,29 @@
 import { expect, test } from '@playwright/test';
 
-test('la home carga y muestra el título correcto', async ({ page }) => {
+test('la home carga y muestra el título correcto', async ({ page, context, baseURL }) => {
+  const token = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+  if (token && baseURL) {
+    const { hostname } = new URL(baseURL);
+    await context.addCookies([
+      {
+        name: '__vercel_protection_bypass',
+        value: token,
+        domain: hostname,
+        path: '/',
+        httpOnly: true,
+        secure: true,
+        sameSite: 'Lax',
+        expires: Date.now() / 1000 + 3600,
+      },
+    ]);
+  }
+
   await page.goto('/'); // usa BASE_URL desde la config
+
+  const title = await page.title();
+  if (title.includes('Login – Vercel')) {
+    throw new Error('Sigue activa la protección: no se aplicó el bypass.');
+  }
+
   await expect(page).toHaveTitle('Buy Buddies');
 });


### PR DESCRIPTION
## Summary
- add Vercel protection bypass header to Playwright config when token provided
- bypass preview protection in smoke test via cookie and login check
- expose bypass secret in e2e CI workflow

## Testing
- `npm test`
- `npm run lint`
- `BASE_URL=http://localhost npm run e2e:smoke` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/.../headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_689a4bc87a388321821c971f77db6c0d