### PR TITLE
Add SafeDep vet workflow and policy

### DIFF
--- a/.github/vet/policy.yml
+++ b/.github/vet/policy.yml
@@ -1,0 +1,8 @@
+version: 1
+rules:
+  - id: block-high-and-supplychain
+    description: Fail on HIGH/CRITICAL or supply-chain compromise indicators
+    match:
+      severities: [HIGH, CRITICAL]
+      supply_chain_indicators: [COMPROMISED_RELEASE, MALICIOUS_INSTALL_SCRIPT]
+    action: FAIL

--- a/.github/workflows/safedep-vet.yml
+++ b/.github/workflows/safedep-vet.yml
@@ -1,0 +1,32 @@
+name: SafeDep vet (PR/push + daily)
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+  schedule:
+    - cron: "0 6 * * *"
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+
+jobs:
+  vet-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run SafeDep vet
+        id: vet
+        uses: safedep/vet-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload SARIF to Code Scanning
+        if: steps.vet.outputs.report != ''
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ steps.vet.outputs.report }}
+          category: vet


### PR DESCRIPTION
## Summary
- add SafeDep vet CI workflow to scan dependencies and upload SARIF
- configure vet policy to fail on high-severity or supply-chain findings

## Testing
- `npm install` *(fails: Not compatible with your version of node/npm)*
- `npm test` *(fails: vitest: not found)*
- `gh api --method PUT repos/placeholder/buy-buddies/branches/develop/protection --field required_status_checks.strict=true --field required_status_checks.contexts[]=vet-scan --field enforce_admins=true --field required_pull_request_reviews.required_approving_review_count=0 --field restrictions=null` *(fails: gh auth login required)*

------
https://chatgpt.com/codex/tasks/task_e_689b651d66808321b4518d4b479de1d6