### PR TITLE
chore: add Dependabot config for npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    # Opcional: agrupa updates menores/patch
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+---


### PR DESCRIPTION
## Summary
- add Dependabot configuration for npm to open daily PRs

## Testing
- `npm run test:unit -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b689bf4a88321af3401f362ac96fa