### PR TITLE
feat: add mock data banner and repository factory

### DIFF
--- a/src/domain/services/productsService.ts
+++ b/src/domain/services/productsService.ts
@@ -1,0 +1,7 @@
+import { getProductsRepository } from '../../infra/repositories/factory.js';
+
+export async function loadProducts() {
+  const repo = getProductsRepository();
+  const items = await repo.list();
+  return { items, isMockData: repo.isMockData } as const;
+}

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -1,0 +1,18 @@
+export interface Product {
+  id: string;
+  name: string;
+  category: string;
+  group: string; // nombre del grupo (anonimizado en mocks)
+  bought: boolean;
+  quantity?: number;
+  unit?: string;
+}
+
+export interface RepositoryCapabilities {
+  isMockData: boolean;
+}
+
+export interface ProductsRepository extends RepositoryCapabilities {
+  list(): Promise<Product[]>;
+  // otros métodos si existen (add/update/delete) sin cambios de firma
+}

--- a/src/infra/repositories/factory.ts
+++ b/src/infra/repositories/factory.ts
@@ -1,0 +1,14 @@
+import { MockProductsRepository } from './products/MockProductsRepository.js';
+import { SheetsProductsRepository } from './products/SheetsProductsRepository.js';
+import type { ProductsRepository } from '../../domain/types.js';
+
+export function getProductsRepository(): ProductsRepository {
+  const googleSheetID = typeof window !== 'undefined'
+    ? window.localStorage.getItem('googleSheetID') || ''
+    : '';
+
+  if (!googleSheetID) {
+    return new MockProductsRepository();
+  }
+  return new SheetsProductsRepository(googleSheetID);
+}

--- a/src/infra/repositories/products/MockProductsRepository.ts
+++ b/src/infra/repositories/products/MockProductsRepository.ts
@@ -1,0 +1,13 @@
+import type { ProductsRepository } from '../../../domain/types.js';
+import { mockProducts } from './mockProducts.js';
+
+export class MockProductsRepository implements ProductsRepository {
+  public readonly isMockData = true;
+
+  async list() {
+    // devolver copia para evitar mutaciones externas
+    return typeof structuredClone === 'function'
+      ? structuredClone(mockProducts)
+      : JSON.parse(JSON.stringify(mockProducts));
+  }
+}

--- a/src/infra/repositories/products/SheetsProductsRepository.ts
+++ b/src/infra/repositories/products/SheetsProductsRepository.ts
@@ -1,0 +1,14 @@
+import type { Product, ProductsRepository } from '../../../domain/types.js';
+
+export class SheetsProductsRepository implements ProductsRepository {
+  public readonly isMockData = false;
+
+  constructor(private googleSheetID: string) {}
+
+  async list(): Promise<Product[]> {
+    const url = `/api/shopping/get?googleSheetId=${encodeURIComponent(this.googleSheetID)}`;
+    const res = await fetch(url);
+    const json = await res.json();
+    return json.data as Product[];
+  }
+}

--- a/src/infra/repositories/products/mockProducts.ts
+++ b/src/infra/repositories/products/mockProducts.ts
@@ -1,0 +1,22 @@
+import type { Product } from '../../../domain/types.js';
+
+// Nombres de grupos inventados (no reales)
+const GROUPS = [
+  'Grupo Abarrotes',
+  'Equipo Frescos',
+  'Brigada Bebidas',
+  'Cuadrilla Limpieza',
+];
+
+export const mockProducts: Product[] = [
+  { id: 'p-001', name: 'Pan',        category: 'Panadería', group: GROUPS[0], bought: false, quantity: 1, unit: 'ud' },
+  { id: 'p-002', name: 'Leche',      category: 'Lácteos',   group: GROUPS[1], bought: false, quantity: 6, unit: 'l'  },
+  { id: 'p-003', name: 'Huevos',     category: 'Frescos',   group: GROUPS[1], bought: false, quantity: 12, unit: 'ud' },
+  { id: 'p-004', name: 'Cerveza',    category: 'Bebidas',   group: GROUPS[2], bought: false, quantity: 24, unit: 'ud' },
+  { id: 'p-005', name: 'Agua',       category: 'Bebidas',   group: GROUPS[2], bought: false, quantity: 12, unit: 'l'  },
+  { id: 'p-006', name: 'Manzanas',   category: 'Fruta',     group: GROUPS[1], bought: false, quantity: 2, unit: 'kg' },
+  { id: 'p-007', name: 'Papel higiénico', category: 'Higiene', group: GROUPS[3], bought: false, quantity: 24, unit: 'ud' },
+  { id: 'p-008', name: 'Detergente', category: 'Limpieza',  group: GROUPS[3], bought: false, quantity: 1, unit: 'ud' },
+  { id: 'p-009', name: 'Tomates',    category: 'Verdura',   group: GROUPS[1], bought: false, quantity: 2, unit: 'kg' },
+  { id: 'p-010', name: 'Café',       category: 'Despensa',  group: GROUPS[0], bought: false, quantity: 2, unit: 'ud' },
+];

--- a/src/ui/app-root.test.ts
+++ b/src/ui/app-root.test.ts
@@ -51,7 +51,8 @@ describe('app-root component', () => {
     const el = await fixture<AppRoot>(html`<app-root></app-root>`);
     await el.updateComplete;
 
-    const button = el.shadowRoot?.querySelector('header md-icon-button') as HTMLElement;
+    const header = el.shadowRoot?.querySelector('app-header') as HTMLElement;
+    const button = header.querySelector('md-icon-button') as HTMLElement;
     const drawer = el.shadowRoot?.querySelector('md-navigation-drawer') as HTMLElement & { opened: boolean };
 
     button.click();
@@ -79,7 +80,8 @@ describe('app-root component', () => {
     const el = await fixture<AppRoot>(html`<app-root></app-root>`);
     await el.updateComplete;
 
-    const menuButton = el.shadowRoot?.querySelector('header md-icon-button') as HTMLElement;
+    const header = el.shadowRoot?.querySelector('app-header') as HTMLElement;
+    const menuButton = header.querySelector('md-icon-button') as HTMLElement;
     const drawer = el.shadowRoot?.querySelector('md-navigation-drawer') as HTMLElement & { opened: boolean };
 
     menuButton.click();

--- a/src/ui/app-root.ts
+++ b/src/ui/app-root.ts
@@ -7,7 +7,9 @@ import './config-page.js';
 
 import { Router } from '@vaadin/router';
 import { css, html, LitElement } from 'lit';
-import { customElement, query } from 'lit/decorators.js';
+import { customElement, query, state } from 'lit/decorators.js';
+import { loadProducts } from '../domain/services/productsService.js';
+import './components/app-header.js';
 
 @customElement('app-root')
 export class AppRoot extends LitElement {
@@ -67,6 +69,12 @@ export class AppRoot extends LitElement {
 
   private router!: Router;
 
+  @state()
+  private products: unknown[] = [];
+
+  @state()
+  private isMockData = false;
+
   private get viteEnv(): string {
     return import.meta.env.VITE_ENV ?? '';
   }
@@ -75,12 +83,16 @@ export class AppRoot extends LitElement {
     return import.meta.env.VITE_BUGSNAG_KEY ?? '';
   }
 
-  override firstUpdated() {
+  override async firstUpdated() {
     this.router = new Router(this.shadowRoot!.getElementById('outlet') as HTMLElement);
     this.router.setRoutes([
       { path: '/', component: 'shopping-list' },
       { path: '/config', component: 'config-page' },
     ]);
+
+    const { items, isMockData } = await loadProducts();
+    this.products = items;
+    this.isMockData = isMockData;
   }
 
   private toggleDrawer = () => {
@@ -94,14 +106,16 @@ export class AppRoot extends LitElement {
 
   override render() {
     return html`
-      <header class="top-bar">
-        <md-icon-button @click=${this.toggleDrawer}>
-          <svg slot="icon" viewBox="0 0 24 24">
-            <path d="M3 6h18v2H3V6zm0 5h18v2H3v-2zm0 5h18v2H3v-2z"></path>
-          </svg>
-        </md-icon-button>
-        <div class="title">Buy Buddies</div>
-      </header>
+      <app-header .isMockData=${this.isMockData}>
+        <div class="top-bar">
+          <md-icon-button @click=${this.toggleDrawer}>
+            <svg slot="icon" viewBox="0 0 24 24">
+              <path d="M3 6h18v2H3V6zm0 5h18v2H3v-2zm0 5h18v2H3v-2z"></path>
+            </svg>
+          </md-icon-button>
+          <div class="title">Buy Buddies</div>
+        </div>
+      </app-header>
 
       <md-navigation-drawer type="modal">
         <div class="drawer-header">

--- a/src/ui/components/app-header.ts
+++ b/src/ui/components/app-header.ts
@@ -1,0 +1,47 @@
+import { LitElement, html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+@customElement('app-header')
+export class AppHeader extends LitElement {
+  @property({ type: Boolean }) isMockData = false;
+
+  static override styles = css`
+    :host {
+      display: block;
+    }
+    .mock-banner {
+      padding: 8px 12px;
+      border-radius: 8px;
+      margin-bottom: 8px;
+      background: #fff3cd; /* amarillito aviso, no crítico */
+      color: #664d03;
+      font-weight: 600;
+    }
+  `;
+
+  override render() {
+    return html`
+      ${this.isMockData
+        ? html`
+            <div
+              class="mock-banner"
+              role="status"
+              aria-label="Aviso: usando datos de prueba"
+              data-test-id="mock-banner"
+            >
+              ⚠ Datos de prueba activos
+            </div>
+          `
+        : null}
+      <header>
+        <slot></slot>
+      </header>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'app-header': AppHeader;
+  }
+}

--- a/tests/e2e/mock-banner.spec.ts
+++ b/tests/e2e/mock-banner.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('banner de mock data', () => {
+  test('muestra el aviso cuando no hay googleSheetID', async ({ page }) => {
+    await page.addInitScript(() => localStorage.removeItem('googleSheetID'));
+    await page.goto('/');
+    const banner = page.getByTestId('mock-banner');
+    await expect(banner).toBeVisible();
+    await expect(
+      page.getByRole('status', { name: /usando datos de prueba/i })
+    ).toBeVisible();
+  });
+
+  test('no muestra el aviso cuando hay googleSheetID', async ({ page }) => {
+    await page.addInitScript(() =>
+      localStorage.setItem('googleSheetID', 'SOME_SHEET_ID')
+    );
+    await page.goto('/');
+    await expect(page.getByTestId('mock-banner')).toHaveCount(0);
+  });
+});

--- a/tests/unit/factory.spec.ts
+++ b/tests/unit/factory.spec.ts
@@ -1,0 +1,19 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { getProductsRepository } from '../../src/infra/repositories/factory.js';
+
+describe('repository factory', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('usa mock si no hay googleSheetID', () => {
+    const repo = getProductsRepository();
+    expect(repo.isMockData).toBe(true);
+  });
+
+  it('usa sheets si hay googleSheetID', () => {
+    localStorage.setItem('googleSheetID', 'SOME_SHEET_ID');
+    const repo = getProductsRepository();
+    expect(repo.isMockData).toBe(false);
+  });
+});

--- a/tests/unit/mockProducts.spec.ts
+++ b/tests/unit/mockProducts.spec.ts
@@ -1,0 +1,17 @@
+import { expect, it } from 'vitest';
+import { mockProducts } from '../../src/infra/repositories/products/mockProducts.js';
+
+it('los grupos del mock son inventados y no vacíos', () => {
+  const groups = new Set(mockProducts.map((p) => p.group));
+  expect(groups.size).toBeGreaterThan(0);
+  for (const g of groups) {
+    expect(g).toMatch(/(Grupo|Equipo|Brigada|Cuadrilla)/);
+  }
+});
+
+it('los productos del mock son reales/comunes', () => {
+  const sample = mockProducts.map((p) => p.name.toLowerCase());
+  expect(sample).toEqual(
+    expect.arrayContaining(['pan', 'leche', 'cerveza', 'agua', 'huevos'])
+  );
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'happy-dom',
-    include: ['**/*.test.ts'],
+    include: ['**/*.test.ts', '**/*.spec.ts'],
     exclude: ['tests/e2e/**', 'node_modules/**', 'dist/**'],
   },
 });


### PR DESCRIPTION
## Summary
- anonymize mock product data and introduce repository factory with mock flag
- show warning banner when using mock data
- add unit and e2e tests for repository selection and banner visibility

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test:unit`
- `npm run test:e2e` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_689b779cc30c8321a704030f09f6ea45