### PR TITLE
feat: add cookie consent banner with Bugsnag gating

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <app-root></app-root>
+    <cookie-consent></cookie-consent>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/src/domain/privacy/cookieConsent.test.ts
+++ b/src/domain/privacy/cookieConsent.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getConsent, saveConsent, hasConsent, onConsentGranted, type CookieConsent } from './cookieConsent.js';
+
+const base: CookieConsent = { necessary: true, analytics: false, marketing: false, timestamp: 1 };
+
+describe('cookieConsent service', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns null when empty', () => {
+    expect(getConsent()).toBeNull();
+  });
+
+  it('saves and reads consent', () => {
+    const c = { ...base, analytics: true, timestamp: Date.now() };
+    saveConsent(c);
+    expect(getConsent()).toEqual(c);
+  });
+
+  it('hasConsent respects categories', () => {
+    saveConsent({ ...base, analytics: true, timestamp: Date.now() });
+    expect(hasConsent('analytics')).toBe(true);
+    expect(hasConsent('marketing')).toBe(false);
+  });
+
+  it('emits event when granted', () => {
+    const spy = vi.fn();
+    const off = onConsentGranted(spy);
+    saveConsent({ ...base, analytics: true, timestamp: Date.now() });
+    expect(spy).toHaveBeenCalledTimes(1);
+    off();
+  });
+});

--- a/src/domain/privacy/cookieConsent.ts
+++ b/src/domain/privacy/cookieConsent.ts
@@ -1,0 +1,46 @@
+const STORAGE_KEY = 'bb.cookieConsent.v1' as const;
+
+export type CookieCategories = 'analytics' | 'marketing';
+export interface CookieConsent {
+  necessary: true;
+  analytics: boolean;
+  marketing: boolean;
+  timestamp: number;
+}
+
+function parse(json: string | null): CookieConsent | null {
+  if (!json) return null;
+  try {
+    const obj = JSON.parse(json);
+    if (
+      typeof obj === 'object' && obj &&
+      obj.necessary === true &&
+      typeof obj.analytics === 'boolean' &&
+      typeof obj.marketing === 'boolean' &&
+      typeof obj.timestamp === 'number'
+    ) return obj as CookieConsent;
+    return null;
+  } catch { return null; }
+}
+
+export function getConsent(): CookieConsent | null {
+  return parse(localStorage.getItem(STORAGE_KEY));
+}
+
+export function saveConsent(consent: CookieConsent): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(consent));
+  if (consent.analytics || consent.marketing) {
+    window.dispatchEvent(new CustomEvent('cookie-consent-granted', { detail: consent }));
+  }
+}
+
+export function hasConsent(cat: CookieCategories): boolean {
+  const c = getConsent();
+  return !!c && c[cat] === true;
+}
+
+export function onConsentGranted(cb: (consent: CookieConsent) => void): () => void {
+  const handler = (e: Event) => cb((e as CustomEvent).detail as CookieConsent);
+  window.addEventListener('cookie-consent-granted', handler as EventListener);
+  return () => window.removeEventListener('cookie-consent-granted', handler as EventListener);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,16 @@
 import { initializeBugsnag } from './bugsnag.js';
+import { hasConsent, onConsentGranted } from './domain/privacy/cookieConsent.js';
 
-initializeBugsnag(import.meta.env.VITE_BUGSNAG_KEY as string | undefined);
+// Inicializar Bugsnag sólo si existe consentimiento analítico
+if (hasConsent('analytics')) {
+  initializeBugsnag(import.meta.env.VITE_BUGSNAG_KEY as string | undefined);
+} else {
+  onConsentGranted((c) => {
+    if (c.analytics) {
+      initializeBugsnag(import.meta.env.VITE_BUGSNAG_KEY as string | undefined);
+    }
+  });
+}
 
 import './ui/app-root.js';
+import './ui/components/cookie-consent.js';

--- a/src/ui/app-root.test.ts
+++ b/src/ui/app-root.test.ts
@@ -1,12 +1,12 @@
 import { fixture, html } from '@open-wc/testing';
-import { beforeEach, describe, expect, it } from 'vitest';
-import { vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@material/web/iconbutton/icon-button.js', () => ({}));
 vi.mock('@material/web/labs/navigationdrawer/navigation-drawer.js', () => ({}));
 vi.mock('@material/web/list/list.js', () => ({}));
 vi.mock('@material/web/list/list-item.js', () => ({}));
 vi.mock('@material/web/textfield/outlined-text-field.js', () => ({}));
+vi.mock('@material/web/checkbox/checkbox.js', () => ({}));
 
 import { AppRoot } from './app-root.js';
 
@@ -29,6 +29,14 @@ if (!customElements.get('md-list-item')) {
 }
 if (!customElements.get('md-outlined-text-field')) {
   customElements.define('md-outlined-text-field', class extends HTMLElement {});
+}
+if (!customElements.get('md-checkbox')) {
+  customElements.define(
+    'md-checkbox',
+    class extends HTMLElement {
+      checked = false;
+    },
+  );
 }
 
 declare global {

--- a/src/ui/components/cookie-consent.test.ts
+++ b/src/ui/components/cookie-consent.test.ts
@@ -1,0 +1,34 @@
+import { fixture, html } from '@open-wc/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@material/web/button/filled-button.js', () => ({}));
+vi.mock('@material/web/button/outlined-button.js', () => ({}));
+vi.mock('@material/web/dialog/dialog.js', () => ({}));
+vi.mock('@material/web/checkbox/checkbox.js', () => ({}));
+
+import './cookie-consent.js';
+
+describe('<cookie-consent>', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('shows banner when no consent', async () => {
+    const el = await fixture<HTMLDivElement>(html`<cookie-consent></cookie-consent>`);
+    const banner = el.shadowRoot!.querySelector('[data-test-id="cookie-banner"]') as HTMLElement;
+    expect(getComputedStyle(banner).display).not.toBe('none');
+  });
+
+  it('hides banner when consent exists', async () => {
+    localStorage.setItem(
+      'bb.cookieConsent.v1',
+      JSON.stringify({
+        necessary: true,
+        analytics: false,
+        marketing: false,
+        timestamp: Date.now(),
+      }),
+    );
+    const el = await fixture<HTMLDivElement>(html`<cookie-consent></cookie-consent>`);
+    const banner = el.shadowRoot!.querySelector('[data-test-id="cookie-banner"]') as HTMLElement;
+    expect(getComputedStyle(banner).display).toBe('none');
+  });
+});

--- a/src/ui/components/cookie-consent.ts
+++ b/src/ui/components/cookie-consent.ts
@@ -1,0 +1,146 @@
+import '@material/web/button/filled-button.js';
+import '@material/web/button/outlined-button.js';
+import '@material/web/checkbox/checkbox.js';
+import '@material/web/dialog/dialog.js';
+
+import { css, html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { type CookieConsent, getConsent, saveConsent } from '../../domain/privacy/cookieConsent.js';
+
+@customElement('cookie-consent')
+export class CookieConsentElement extends LitElement {
+  static override styles = css`
+    :host {
+      position: fixed;
+      inset-inline: 0;
+      bottom: 0;
+      z-index: 2000;
+      display: block;
+    }
+    .banner {
+      margin: 12px;
+      padding: 12px 16px;
+      border-radius: 12px;
+      background: #fff;
+      box-shadow: 0 4px 10px rgba(0, 0, 0, 0.12);
+      display: flex;
+      gap: 12px;
+      align-items: start;
+    }
+    .text {
+      flex: 1;
+    }
+    .actions {
+      display: flex;
+      gap: 8px;
+    }
+    .hidden {
+      display: none;
+    }
+    .title {
+      font-weight: 600;
+      margin-bottom: 4px;
+    }
+  `;
+
+  @state() private open = false;
+  @state() private showBanner = false;
+  @state() private analytics = false;
+  @state() private marketing = false;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    const consent = getConsent();
+    this.showBanner = !consent;
+    if (consent) {
+      this.analytics = consent.analytics;
+      this.marketing = consent.marketing;
+    }
+  }
+
+  private acceptAll = () => {
+    this.persist({ necessary: true, analytics: true, marketing: true, timestamp: Date.now() });
+  };
+
+  private rejectOptional = () => {
+    this.persist({ necessary: true, analytics: false, marketing: false, timestamp: Date.now() });
+  };
+
+  private openConfig = () => {
+    this.open = true;
+  };
+  private closeConfig = () => {
+    this.open = false;
+  };
+
+  private saveConfig = () => {
+    this.persist({ necessary: true, analytics: this.analytics, marketing: this.marketing, timestamp: Date.now() });
+    this.closeConfig();
+  };
+
+  private persist(consent: CookieConsent) {
+    saveConsent(consent);
+    this.showBanner = false;
+    this.dispatchEvent(new CustomEvent('consent-changed', { detail: consent, bubbles: true, composed: true }));
+  }
+
+  override render() {
+    return html`
+      <div
+        class=${this.showBanner ? 'banner' : 'banner hidden'}
+        role="region"
+        aria-label="Aviso de cookies"
+        data-test-id="cookie-banner"
+      >
+        <div class="text">
+          <div class="title">🍪 Este sitio utiliza cookies</div>
+          <div>
+            Usamos cookies necesarias para que la web funcione y opcionales (analíticas/marketing) para mejorar la
+            experiencia. Puedes aceptarlas todas o configurarlas.
+          </div>
+        </div>
+        <div class="actions">
+          <md-outlined-button data-test-id="btn-config" @click=${this.openConfig}>Configurar</md-outlined-button>
+          <md-outlined-button data-test-id="btn-reject" @click=${this.rejectOptional}
+            >Rechazar opcionales</md-outlined-button
+          >
+          <md-filled-button data-test-id="btn-accept-all" @click=${this.acceptAll}>Aceptar todas</md-filled-button>
+        </div>
+      </div>
+
+      <md-dialog ?open=${this.open} role="dialog" aria-label="Configurar cookies" @closed=${this.closeConfig}>
+        <div slot="headline">Preferencias de cookies</div>
+        <div slot="content">
+          <p><strong>Necesarias</strong>: siempre activas (imprescindibles).</p>
+          <md-checkbox checked disabled aria-label="Cookies necesarias">Necesarias</md-checkbox>
+
+          <md-checkbox
+            .checked=${this.analytics}
+            @change=${(e: Event) => (this.analytics = (e.target as HTMLInputElement).checked)}
+            data-test-id="chk-analytics"
+            aria-label="Cookies analíticas"
+            >Analíticas</md-checkbox
+          >
+
+          <md-checkbox
+            .checked=${this.marketing}
+            @change=${(e: Event) => (this.marketing = (e.target as HTMLInputElement).checked)}
+            data-test-id="chk-marketing"
+            aria-label="Cookies de marketing"
+            >Marketing</md-checkbox
+          >
+        </div>
+        <div slot="actions">
+          <md-outlined-button @click=${this.closeConfig}>Cancelar</md-outlined-button>
+          <md-filled-button data-test-id="btn-save-config" @click=${this.saveConfig}>Guardar</md-filled-button>
+        </div>
+      </md-dialog>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'cookie-consent': CookieConsentElement;
+  }
+}

--- a/src/ui/config-page.test.ts
+++ b/src/ui/config-page.test.ts
@@ -1,8 +1,8 @@
 import { fixture, html } from '@open-wc/testing';
-import { describe, expect, it } from 'vitest';
-import { vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('@material/web/textfield/outlined-text-field.js', () => ({}));
+vi.mock('@material/web/checkbox/checkbox.js', () => ({}));
 
 import './config-page.js';
 
@@ -11,6 +11,15 @@ if (!customElements.get('md-outlined-text-field')) {
     'md-outlined-text-field',
     class extends HTMLElement {
       value = '';
+    },
+  );
+}
+
+if (!customElements.get('md-checkbox')) {
+  customElements.define(
+    'md-checkbox',
+    class extends HTMLElement {
+      checked = false;
     },
   );
 }
@@ -26,5 +35,28 @@ describe('config-page component', () => {
     input.value = 'new-id';
     input.dispatchEvent(new Event('input'));
     expect(localStorage.getItem('googleSheetID')).toBe('new-id');
+  });
+
+  it('reflects and updates cookie consent', async () => {
+    localStorage.clear();
+    localStorage.setItem(
+      'bb.cookieConsent.v1',
+      JSON.stringify({
+        necessary: true,
+        analytics: true,
+        marketing: false,
+        timestamp: Date.now(),
+      }),
+    );
+    const el = await fixture<any>(html`<config-page></config-page>`);
+    await el.updateComplete;
+    const analytics = el.shadowRoot!.querySelector('[data-test-id="config-analytics"]') as any;
+    const marketing = el.shadowRoot!.querySelector('[data-test-id="config-marketing"]') as any;
+    expect(analytics.checked).toBe(true);
+    expect(marketing.checked).toBe(false);
+    analytics.checked = false;
+    analytics.dispatchEvent(new Event('change'));
+    const stored = JSON.parse(localStorage.getItem('bb.cookieConsent.v1')!);
+    expect(stored.analytics).toBe(false);
   });
 });

--- a/src/ui/config-page.ts
+++ b/src/ui/config-page.ts
@@ -1,8 +1,10 @@
+import '@material/web/checkbox/checkbox.js';
 import '@material/web/textfield/outlined-text-field.js';
 
 import { Router } from '@vaadin/router';
 import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
+import { getConsent, saveConsent } from '../domain/privacy/cookieConsent.js';
 
 @customElement('config-page')
 export class ConfigPage extends LitElement {
@@ -22,9 +24,20 @@ export class ConfigPage extends LitElement {
   @state()
   private googleSheetID = '';
 
+  @state()
+  private analytics = false;
+
+  @state()
+  private marketing = false;
+
   override connectedCallback() {
     super.connectedCallback();
     this.googleSheetID = localStorage.getItem('googleSheetID') ?? '';
+    const consent = getConsent();
+    if (consent) {
+      this.analytics = consent.analytics;
+      this.marketing = consent.marketing;
+    }
   }
 
   private onInput(e: Event) {
@@ -36,6 +49,25 @@ export class ConfigPage extends LitElement {
     Router.go('/');
   }
 
+  private updateConsent() {
+    saveConsent({
+      necessary: true,
+      analytics: this.analytics,
+      marketing: this.marketing,
+      timestamp: Date.now(),
+    });
+  }
+
+  private onAnalyticsChange(e: Event) {
+    this.analytics = (e.target as HTMLInputElement).checked;
+    this.updateConsent();
+  }
+
+  private onMarketingChange(e: Event) {
+    this.marketing = (e.target as HTMLInputElement).checked;
+    this.updateConsent();
+  }
+
   override render() {
     return html`
       <h1>Configuración</h1>
@@ -44,6 +76,16 @@ export class ConfigPage extends LitElement {
         .value=${this.googleSheetID}
         @input=${this.onInput}
       ></md-outlined-text-field>
+      <div>
+        <md-checkbox .checked=${this.analytics} @change=${this.onAnalyticsChange} data-test-id="config-analytics"
+          >Cookies analíticas</md-checkbox
+        >
+      </div>
+      <div>
+        <md-checkbox .checked=${this.marketing} @change=${this.onMarketingChange} data-test-id="config-marketing"
+          >Cookies de marketing</md-checkbox
+        >
+      </div>
       <button @click=${this.goHome}>Volver</button>
     `;
   }

--- a/tests/e2e/cookies.spec.ts
+++ b/tests/e2e/cookies.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('cookie banner', () => {
+  test.beforeEach(async ({ page, context }) => {
+    // empezar sin consentimientos
+    await context.clearCookies();
+    await page.goto('/');
+    await page.evaluate(() => localStorage.clear());
+  });
+
+  test('appear, accept all, persist', async ({ page }) => {
+    const banner = page.getByTestId('cookie-banner');
+    await expect(banner).toBeVisible();
+
+    await page.getByTestId('btn-accept-all').click();
+    await expect(banner).toBeHidden();
+
+    await page.reload();
+    await expect(page.getByTestId('cookie-banner')).toBeHidden();
+  });
+
+  test('configure -> reject optional', async ({ page }) => {
+    await page.getByTestId('btn-config').click();
+    await page.getByRole('button', { name: 'Guardar' }).click(); // por defecto ambos false
+    await expect(page.getByTestId('cookie-banner')).toBeHidden();
+  });
+});


### PR DESCRIPTION
## Summary
- add cookie consent domain service and UI banner
- gate Bugsnag initialization based on analytics consent
- expose cookie preferences on settings page
- cover cookie consent logic with unit and e2e tests
- fix e2e to preserve localStorage across reloads
- stabilize consent tests by binding checkboxes and mocking Material components
- reset local storage on same-origin before running cookie banner e2e

## Testing
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
- `npm run test:unit` *(fails: vitest: not found)*
- `BASE_URL=http://localhost:5173 npm run test:e2e` *(fails: playwright: not found)*
- `npx playwright install` *(requires confirmation prompt)*

------
https://chatgpt.com/codex/tasks/task_e_689c2cf848c88321a6b464d91a681516