### PR TITLE
feat: make cookie banner responsive

### DIFF
--- a/src/ui/components/cookie-consent.ts
+++ b/src/ui/components/cookie-consent.ts
@@ -41,6 +41,16 @@ export class CookieConsentElement extends LitElement {
       font-weight: 600;
       margin-bottom: 4px;
     }
+
+    @media (max-width: 600px) {
+      .banner {
+        flex-direction: column;
+      }
+      .actions {
+        align-self: flex-end;
+        flex-wrap: wrap;
+      }
+    }
   `;
 
   @state() private open = false;

--- a/tests/e2e/cookies.spec.ts
+++ b/tests/e2e/cookies.spec.ts
@@ -24,4 +24,12 @@ test.describe('cookie banner', () => {
     await page.getByRole('button', { name: 'Guardar' }).click(); // por defecto ambos false
     await expect(page.getByTestId('cookie-banner')).toBeHidden();
   });
+
+  test('responsive on small screens', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    const banner = page.getByTestId('cookie-banner');
+    await expect(banner).toBeVisible();
+    const direction = await banner.evaluate((el) => getComputedStyle(el).flexDirection);
+    expect(direction).toBe('column');
+  });
 });


### PR DESCRIPTION
## Summary
- make cookie consent banner adapt layout on small screens
- add e2e test ensuring responsive behavior

## Testing
- `npm test`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist; requires `npx playwright install`, which fails to download)*

------
https://chatgpt.com/codex/tasks/task_e_689cbf2e2e0c8321bb80cff38a9896cf