### PR TITLE
Add cookie section with named cookie options

### DIFF
--- a/src/ui/config-page.test.ts
+++ b/src/ui/config-page.test.ts
@@ -59,4 +59,16 @@ describe('config-page component', () => {
     const stored = JSON.parse(localStorage.getItem('bb.cookieConsent.v1')!);
     expect(stored.analytics).toBe(false);
   });
+
+  it('renders a cookie section with named checkboxes', async () => {
+    localStorage.clear();
+    const el = await fixture<any>(html`<config-page></config-page>`);
+    await el.updateComplete;
+    const section = el.shadowRoot!.querySelector('[data-test-id="cookie-section"]');
+    expect(section).not.toBeNull();
+    const analytics = el.shadowRoot!.querySelector('[data-test-id="config-analytics"]');
+    const marketing = el.shadowRoot!.querySelector('[data-test-id="config-marketing"]');
+    expect(analytics?.getAttribute('name')).toBe('analytics');
+    expect(marketing?.getAttribute('name')).toBe('marketing');
+  });
 });

--- a/src/ui/config-page.ts
+++ b/src/ui/config-page.ts
@@ -19,6 +19,11 @@ export class ConfigPage extends LitElement {
       margin: 0;
       font-size: 1.5rem;
     }
+
+    h2 {
+      margin: 16px 0 8px;
+      font-size: 1.2rem;
+    }
   `;
 
   @state()
@@ -76,16 +81,29 @@ export class ConfigPage extends LitElement {
         .value=${this.googleSheetID}
         @input=${this.onInput}
       ></md-outlined-text-field>
-      <div>
-        <md-checkbox .checked=${this.analytics} @change=${this.onAnalyticsChange} data-test-id="config-analytics"
-          >Cookies analíticas</md-checkbox
-        >
-      </div>
-      <div>
-        <md-checkbox .checked=${this.marketing} @change=${this.onMarketingChange} data-test-id="config-marketing"
-          >Cookies de marketing</md-checkbox
-        >
-      </div>
+      <section aria-labelledby="cookie-settings" data-test-id="cookie-section">
+        <h2 id="cookie-settings">Cookies</h2>
+        <div>
+          <md-checkbox
+            name="analytics"
+            aria-label="Cookies analíticas"
+            .checked=${this.analytics}
+            @change=${this.onAnalyticsChange}
+            data-test-id="config-analytics"
+            >Cookies analíticas</md-checkbox
+          >
+        </div>
+        <div>
+          <md-checkbox
+            name="marketing"
+            aria-label="Cookies de marketing"
+            .checked=${this.marketing}
+            @change=${this.onMarketingChange}
+            data-test-id="config-marketing"
+            >Cookies de marketing</md-checkbox
+          >
+        </div>
+      </section>
       <button @click=${this.goHome}>Volver</button>
     `;
   }


### PR DESCRIPTION
## Summary
- Label cookie preferences in configuration page with distinct section and named checkboxes
- Add tests for cookie section

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cbd9802b883218d8bc34c9e8cca69