### PR TITLE
feat: add minimal i18n support

### DIFF
--- a/src/domain/i18n/dicts.ts
+++ b/src/domain/i18n/dicts.ts
@@ -1,0 +1,17 @@
+import type { Dict } from './types.js';
+
+export const ES_DICT: Dict = {
+  'menu.home': 'Inicio',
+  'menu.products': 'Productos',
+  'menu.list': 'Lista de la compra',
+  'menu.groups': 'Grupos',
+  'menu.settings': 'Ajustes',
+};
+
+export const EN_DICT: Dict = {
+  'menu.home': 'Home',
+  'menu.products': 'Products',
+  'menu.list': 'Shopping list',
+  'menu.groups': 'Groups',
+  'menu.settings': 'Settings',
+};

--- a/src/domain/i18n/i18n.service.ts
+++ b/src/domain/i18n/i18n.service.ts
@@ -1,0 +1,31 @@
+import { EN_DICT, ES_DICT } from './dicts.js';
+import type { Dict, I18nService, I18nState, Lang } from './types.js';
+
+const DICTS: Record<Lang, Dict> = { es: ES_DICT, en: EN_DICT };
+
+class I18nStore implements I18nService {
+  #state: I18nState;
+  #listeners = new Set<() => void>();
+
+  constructor(defaultLang: Lang) {
+    this.#state = { lang: defaultLang, dict: DICTS[defaultLang] };
+  }
+  getLang(): Lang {
+    return this.#state.lang;
+  }
+  setLang(lang: Lang): void {
+    if (this.#state.lang === lang) return;
+    this.#state = { lang, dict: DICTS[lang] };
+    this.#listeners.forEach((cb) => cb());
+  }
+  t(key: keyof Dict): string {
+    return this.#state.dict[key];
+  }
+  subscribe(cb: () => void): () => void {
+    this.#listeners.add(cb);
+    return () => this.#listeners.delete(cb);
+  }
+}
+
+export const createI18n = (defaultLang: Lang): I18nService =>
+  new I18nStore(defaultLang);

--- a/src/domain/i18n/types.ts
+++ b/src/domain/i18n/types.ts
@@ -1,0 +1,23 @@
+export type Lang = 'es' | 'en';
+export const isLang = (v: unknown): v is Lang => v === 'es' || v === 'en';
+
+export type I18nKey =
+  | 'menu.home'
+  | 'menu.products'
+  | 'menu.list'
+  | 'menu.groups'
+  | 'menu.settings';
+
+export type Dict = Record<I18nKey, string>;
+
+export interface I18nState {
+  lang: Lang;
+  dict: Dict;
+}
+
+export interface I18nService {
+  getLang(): Lang;
+  setLang(lang: Lang): void;
+  t(key: I18nKey): string;
+  subscribe(cb: () => void): () => void;
+}

--- a/src/infrastructure/storage/localLanguage.repository.ts
+++ b/src/infrastructure/storage/localLanguage.repository.ts
@@ -1,0 +1,20 @@
+import { isLang, type Lang } from '../../domain/i18n/types.js';
+
+const KEY = 'bb.lang';
+
+export function loadLang(): Lang {
+  try {
+    const raw = localStorage.getItem(KEY);
+    return isLang(raw) ? raw : 'es';
+  } catch {
+    return 'es';
+  }
+}
+
+export function saveLang(lang: Lang): void {
+  try {
+    localStorage.setItem(KEY, lang);
+  } catch {
+    /* noop: sin bloqueo si el navegador no permite persistir */
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,10 @@
 import { initializeBugsnag } from './bugsnag.js';
 import { hasConsent, onConsentGranted } from './domain/privacy/cookieConsent.js';
+import { createI18n } from './domain/i18n/i18n.service.js';
+import { loadLang, saveLang } from './infrastructure/storage/localLanguage.repository.js';
+
+export const i18n = createI18n(loadLang());
+i18n.subscribe(() => saveLang(i18n.getLang()));
 
 // Inicializar Bugsnag sólo si existe consentimiento analítico
 if (hasConsent('analytics')) {

--- a/src/ui/app-root.test.ts
+++ b/src/ui/app-root.test.ts
@@ -75,12 +75,12 @@ describe('app-root component', () => {
 
     const drawer = el.shadowRoot?.querySelector('md-navigation-drawer') as HTMLElement & { opened: boolean };
     drawer.opened = true;
-    const items = drawer.querySelectorAll('md-list-item');
-    (items[1] as HTMLElement).click();
+    const settings = drawer.querySelector('[data-test-id="menu-item-settings"]') as HTMLElement;
+    settings.click();
     await new Promise((r) => setTimeout(r));
 
     expect(window.location.pathname).toBe('/config');
-    expect(el.shadowRoot?.textContent).toContain('Configuración');
+    expect(el.shadowRoot?.textContent).toContain('Ajustes');
     // Environment variables may not be available in this test environment
   });
 

--- a/src/ui/app-root.ts
+++ b/src/ui/app-root.ts
@@ -4,6 +4,7 @@ import '@material/web/list/list.js';
 import '@material/web/list/list-item.js';
 import './shopping-list.js';
 import './config-page.js';
+import { i18n } from '../main.js';
 
 import { Router } from '@vaadin/router';
 import { css, html, LitElement } from 'lit';
@@ -75,6 +76,8 @@ export class AppRoot extends LitElement {
   @state()
   private isMockData = false;
 
+  private _unsub?: () => void;
+
   private get viteEnv(): string {
     return import.meta.env.VITE_ENV ?? '';
   }
@@ -93,6 +96,16 @@ export class AppRoot extends LitElement {
     const { items, isMockData } = await loadProducts();
     this.products = items;
     this.isMockData = isMockData;
+  }
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this._unsub = i18n.subscribe(() => this.requestUpdate());
+  }
+
+  override disconnectedCallback() {
+    this._unsub?.();
+    super.disconnectedCallback();
   }
 
   private toggleDrawer = () => {
@@ -129,8 +142,27 @@ export class AppRoot extends LitElement {
           </md-icon-button>
         </div>
         <md-list>
-          <md-list-item @click=${() => this.navigate('/')}>Lista</md-list-item>
-          <md-list-item @click=${() => this.navigate('/config')}>Configuración</md-list-item>
+          <md-list-item
+            data-test-id="menu-item-home"
+            @click=${() => this.navigate('/')}
+            >${i18n.t('menu.home')}</md-list-item
+          >
+          <md-list-item data-test-id="menu-item-products"
+            >${i18n.t('menu.products')}</md-list-item
+          >
+          <md-list-item
+            data-test-id="menu-item-list"
+            @click=${() => this.navigate('/')}
+            >${i18n.t('menu.list')}</md-list-item
+          >
+          <md-list-item data-test-id="menu-item-groups"
+            >${i18n.t('menu.groups')}</md-list-item
+          >
+          <md-list-item
+            data-test-id="menu-item-settings"
+            @click=${() => this.navigate('/config')}
+            >${i18n.t('menu.settings')}</md-list-item
+          >
         </md-list>
       </md-navigation-drawer>
 

--- a/src/ui/components/app-header.ts
+++ b/src/ui/components/app-header.ts
@@ -1,5 +1,8 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { i18n } from '../../main.js';
+import type { Lang } from '../../domain/i18n/types.js';
+import '@material/web/iconbutton/icon-button.js';
 
 @customElement('app-header')
 export class AppHeader extends LitElement {
@@ -17,9 +20,17 @@ export class AppHeader extends LitElement {
       color: #664d03;
       font-weight: 600;
     }
+    header {
+      display: flex;
+      align-items: center;
+    }
+    ::slotted(*) {
+      flex: 1;
+    }
   `;
 
   override render() {
+    const flag = i18n.getLang() === 'es' ? '🇪🇸' : '🇬🇧';
     return html`
       ${this.isMockData
         ? html`
@@ -35,9 +46,32 @@ export class AppHeader extends LitElement {
         : null}
       <header>
         <slot></slot>
+        <md-icon-button
+          data-test-id="lang-toggle"
+          aria-label="${
+            i18n.getLang() === 'es' ? 'Cambiar a inglés' : 'Switch to Spanish'
+          }"
+          title="${i18n.getLang() === 'es' ? 'Cambiar a inglés' : 'Switch to Spanish'}"
+          @click=${this.onToggleLang}
+        >
+          <span slot="icon">${flag}</span>
+        </md-icon-button>
       </header>
     `;
   }
+
+  private onToggleLang = () => {
+    const next: Lang = i18n.getLang() === 'es' ? 'en' : 'es';
+    i18n.setLang(next);
+    this.dispatchEvent(
+      new CustomEvent('lang-changed', {
+        detail: { lang: next },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+    this.requestUpdate();
+  };
 }
 
 declare global {

--- a/tests/e2e/i18n-menu.spec.ts
+++ b/tests/e2e/i18n-menu.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect, type Page } from '@playwright/test';
+
+const openMenu = async (page: Page) => {
+  await page.locator('app-header md-icon-button').first().click();
+};
+
+test('cambiar idioma desde cabecera traduce el menú lateral', async ({ page }) => {
+  await page.goto('/');
+  await openMenu(page);
+  await page.getByTestId('menu-item-products').waitFor();
+  const before = await page.getByTestId('menu-item-products').innerText();
+  await page.getByTestId('lang-toggle').click();
+  await openMenu(page);
+  await expect(page.getByTestId('menu-item-products')).not.toHaveText(before);
+});

--- a/tests/unit/i18n.service.spec.ts
+++ b/tests/unit/i18n.service.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { createI18n } from '../../src/domain/i18n/i18n.service.js';
+
+describe('i18n service', () => {
+  it('inicia en ES por defecto', () => {
+    const i = createI18n('es');
+    expect(i.getLang()).toBe('es');
+    expect(i.t('menu.products')).toBeTruthy();
+  });
+  it('cambia idioma y notifica', () => {
+    const i = createI18n('es');
+    let notified = 0;
+    const unsub = i.subscribe(() => notified++);
+    i.setLang('en');
+    expect(i.getLang()).toBe('en');
+    expect(notified).toBe(1);
+    unsub();
+  });
+});

--- a/tests/unit/localLanguage.repository.spec.ts
+++ b/tests/unit/localLanguage.repository.spec.ts
@@ -1,0 +1,13 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { loadLang, saveLang } from '../../src/infrastructure/storage/localLanguage.repository.js';
+
+describe('localLanguage.repository', () => {
+  beforeEach(() => localStorage.clear());
+  it('retorna es si no hay valor', () => {
+    expect(loadLang()).toBe('es');
+  });
+  it('persiste y lee el idioma', () => {
+    saveLang('en');
+    expect(loadLang()).toBe('en');
+  });
+});


### PR DESCRIPTION
## Summary
- add ES/EN dictionaries and i18n service with localStorage persistence
- expose language toggle in header and translate side menu items
- cover i18n service, persistence repo and menu toggle with tests
- open side drawer in i18n e2e spec before asserting translations
- ensure header uses flex layout so language toggle is visible

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test:unit`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*
- `npx playwright install --with-deps chromium` *(fails: Download failed: server returned code 403 body 'Domain forbidden')*


------
https://chatgpt.com/codex/tasks/task_e_689cc5d4ea34832185822e5906455336